### PR TITLE
Builder Pattern refactoring

### DIFF
--- a/src/main/java/sqltoregex/property/PropertyMapBuilder.java
+++ b/src/main/java/sqltoregex/property/PropertyMapBuilder.java
@@ -12,11 +12,12 @@ import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
 
-
 public class PropertyMapBuilder {
     private final Set<OrderRotation> orderRotations;
     private final Map<PropertyOption, Property<?>> propertyMap;
     private final Set<SpellingMistake> spellingMistakes;
+    private static final String UNSUPPORTED_BUILD_WITH = "Unsupported build with:";
+    private static final String STRING_SYNONYM_DELIMITER = ";";
 
     public PropertyMapBuilder() {
         this.propertyMap = new EnumMap<>(PropertyOption.class);
@@ -37,7 +38,7 @@ public class PropertyMapBuilder {
         return this.propertyMap;
     }
 
-    public PropertyMapBuilder withPropertyOption(PropertyOption propertyOption) {
+    public void withPropertyOption(PropertyOption propertyOption) {
         switch (propertyOption) {
             case KEYWORDSPELLING, COLUMNNAMESPELLING, TABLENAMESPELLING -> {
                 SpellingMistake spellingMistake = new SpellingMistake(propertyOption);
@@ -49,9 +50,8 @@ public class PropertyMapBuilder {
                 this.propertyMap.put(propertyOption, orderRotation);
                 orderRotations.add(orderRotation);
             }
-            default -> throw new IllegalArgumentException("Unsupported build with:" + propertyOption);
+            default -> throw new IllegalArgumentException(UNSUPPORTED_BUILD_WITH + propertyOption);
         }
-        return this;
     }
 
     public PropertyMapBuilder withPropertyOptionSet(Set<PropertyOption> propertyOptions) {
@@ -73,7 +73,7 @@ public class PropertyMapBuilder {
                 }
                 this.propertyMap.put(propertyOption, synonymGenerator);
             }
-            default -> throw new IllegalArgumentException("Unsupported build with:" + propertyOption);
+            default -> throw new IllegalArgumentException(UNSUPPORTED_BUILD_WITH + propertyOption);
         }
         return this;
     }
@@ -92,13 +92,13 @@ public class PropertyMapBuilder {
                     if (!synonyms.isEmpty()) {
                         StringSynonymGenerator aggregateFunctionSynonymGenerator = new StringSynonymGenerator(propertyOption);
                         for (String singleSynonym : synonyms) {
-                            aggregateFunctionSynonymGenerator.addSynonymFor(singleSynonym.split(";")[0].strip(),
-                                                                            singleSynonym.split(";")[1].strip());
+                            aggregateFunctionSynonymGenerator.addSynonymFor(singleSynonym.split(STRING_SYNONYM_DELIMITER)[0].strip(),
+                                                                            singleSynonym.split(STRING_SYNONYM_DELIMITER)[1].strip());
                         }
                         this.propertyMap.put(propertyOption, aggregateFunctionSynonymGenerator);
                     }
                 }
-                default -> throw new IllegalArgumentException("Unsupported build with:" + propertyOption);
+                default -> throw new IllegalArgumentException(UNSUPPORTED_BUILD_WITH + propertyOption);
             }
         return this;
     }

--- a/src/main/java/sqltoregex/property/PropertyMapBuilder.java
+++ b/src/main/java/sqltoregex/property/PropertyMapBuilder.java
@@ -92,8 +92,8 @@ public class PropertyMapBuilder {
                     if (!synonyms.isEmpty()) {
                         StringSynonymGenerator aggregateFunctionSynonymGenerator = new StringSynonymGenerator(propertyOption);
                         for (String singleSynonym : synonyms) {
-                            aggregateFunctionSynonymGenerator.addSynonymFor(singleSynonym.split(",")[0],
-                                                                            singleSynonym.split(",")[1]);
+                            aggregateFunctionSynonymGenerator.addSynonymFor(singleSynonym.split(";")[0].strip(),
+                                                                            singleSynonym.split(";")[1].strip());
                         }
                         this.propertyMap.put(propertyOption, aggregateFunctionSynonymGenerator);
                     }

--- a/src/main/java/sqltoregex/property/PropertyOption.java
+++ b/src/main/java/sqltoregex/property/PropertyOption.java
@@ -13,7 +13,7 @@ public enum PropertyOption {
     TIMESYNONYMS,
     DATETIMESYNONYMS,
     AGGREGATEFUNCTIONLANG,
-    DEFAULT;
-    //When extending this class keep the naming of the enums and the xml tags the same. That they can easily be
-    // transformed in each other.
+    DEFAULT
+    // when extending this class keep the naming of the enums and the xml tags the same
+    // that they can easily be transformed in each other
 }

--- a/src/main/java/sqltoregex/property/regexgenerator/OrderRotation.java
+++ b/src/main/java/sqltoregex/property/regexgenerator/OrderRotation.java
@@ -13,7 +13,7 @@ import java.util.*;
  * SELECT (?:table1\s*,\s*table2|table2\s*,\s*table1)
  */
 public class OrderRotation implements Property<PropertyOption>, RegExGenerator<List<String>> {
-    private final StringBuilder tableNameOrderRegEx = new StringBuilder();
+    private final StringBuilder orderRotationOfValueList = new StringBuilder();
     private SpellingMistake spellingMistake;
     private final PropertyOption propertyoption;
     protected boolean isCapturingGroup = false;
@@ -31,60 +31,60 @@ public class OrderRotation implements Property<PropertyOption>, RegExGenerator<L
 
     @Override
     public Set<PropertyOption> getSettings() {
-        return new HashSet<>(Arrays.asList(propertyoption));
+        return new HashSet<>(List.of(propertyoption));
     }
 
     /**
      * helper function for recursive tablename order concatenation
      * @param amount Integer
-     * @param tableNames List<String>
+     * @param valueList List<String>
      */
-    private void rekTableNameOrder(Integer amount, List<String> tableNames){
-        StringBuilder tableNameOrderRegExSingleElement = new StringBuilder();
+    private void orderRotationRek(Integer amount, List<String> valueList){
+        StringBuilder singleValue = new StringBuilder();
         if (amount == 1) {
-            for(String el : tableNames){
+            for(String value : valueList){
                 if(spellingMistake != null) {
-                    tableNameOrderRegExSingleElement.append(spellingMistake.generateRegExFor(el));
+                    singleValue.append(spellingMistake.generateRegExFor(value));
                 } else{
-                    tableNameOrderRegExSingleElement.append(el);
+                    singleValue.append(value);
                 }
-                tableNameOrderRegExSingleElement.append("\\s*,\\s*");
+                singleValue.append("\\s*,\\s*");
             }
-            tableNameOrderRegExSingleElement.replace(tableNameOrderRegExSingleElement.length()-7, tableNameOrderRegExSingleElement.length(), "");
-            tableNameOrderRegExSingleElement.append("|");
-            tableNameOrderRegEx.append(tableNameOrderRegExSingleElement);
+            singleValue.replace(singleValue.length()-7, singleValue.length(), "");
+            singleValue.append("|");
+            orderRotationOfValueList.append(singleValue);
         } else {
-            rekTableNameOrder(amount-1, tableNames);
+            orderRotationRek(amount-1, valueList);
             for(int i = 0; i < amount-1;i++){
                 if (amount % 2 == 0){
                     String temp;
-                    temp = tableNames.get(amount-1);
-                    tableNames.set(amount-1, tableNames.get(i));
-                    tableNames.set(i, temp);
+                    temp = valueList.get(amount-1);
+                    valueList.set(amount-1, valueList.get(i));
+                    valueList.set(i, temp);
                 } else {
                     String temp;
-                    temp = tableNames.get(amount-1);
-                    tableNames.set(amount-1, tableNames.get(0));
-                    tableNames.set(0, temp);
+                    temp = valueList.get(amount-1);
+                    valueList.set(amount-1, valueList.get(0));
+                    valueList.set(0, temp);
                 }
-                rekTableNameOrder(amount-1, tableNames);
+                orderRotationRek(amount-1, valueList);
             }
         }
     }
 
     /**
      * combine every possible table name order to a non-capturing regex group, optional with alternative writing styles
-     * @param tableNameList List<String>
+     * @param valueList List<String>
      * @return Regex (non-capturing group)
      */
-    public String generateRegExFor(List<String> tableNameList){
-        Assert.notNull(tableNameList, "tableNameList must not be null");
-        tableNameOrderRegEx.append(isCapturingGroup ? '(' : "(?:");
-        Integer amountOfTables = tableNameList.size();
-        rekTableNameOrder(amountOfTables, tableNameList);
-        tableNameOrderRegEx.replace(tableNameOrderRegEx.length()-1, tableNameOrderRegEx.length(), "");
-        tableNameOrderRegEx.append(')');
-        return tableNameOrderRegEx.toString();
+    public String generateRegExFor(List<String> valueList){
+        Assert.notNull(valueList, "Value list must not be null!");
+        orderRotationOfValueList.append(isCapturingGroup ? '(' : "(?:");
+        Integer amountOfElements = valueList.size();
+        orderRotationRek(amountOfElements, valueList);
+        orderRotationOfValueList.replace(orderRotationOfValueList.length()-1, orderRotationOfValueList.length(), "");
+        orderRotationOfValueList.append(')');
+        return orderRotationOfValueList.toString();
     }
 
     public void setSpellingMistake(SpellingMistake spellingMistake){

--- a/src/main/java/sqltoregex/property/regexgenerator/OrderRotation.java
+++ b/src/main/java/sqltoregex/property/regexgenerator/OrderRotation.java
@@ -96,6 +96,10 @@ public class OrderRotation implements Property<PropertyOption>, RegExGenerator<L
         return spellingMistake;
     }
 
+    /**
+     * Sets whether there will be an enclosing non capturing group (?: ... ) around the generated regEx.
+     * @param capturingGroup true for capturing group false for non-capturing group
+     */
     public void setCapturingGroup(boolean capturingGroup) {
         isCapturingGroup = capturingGroup;
     }

--- a/src/main/java/sqltoregex/property/regexgenerator/OrderRotation.java
+++ b/src/main/java/sqltoregex/property/regexgenerator/OrderRotation.java
@@ -79,12 +79,11 @@ public class OrderRotation implements Property<PropertyOption>, RegExGenerator<L
      */
     public String generateRegExFor(List<String> tableNameList){
         Assert.notNull(tableNameList, "tableNameList must not be null");
-        if(Boolean.TRUE.equals(this.isCapturingGroup)) tableNameOrderRegEx.append("(?:");
-        else tableNameOrderRegEx.append("(");
+        tableNameOrderRegEx.append(isCapturingGroup ? '(' : "(?:");
         Integer amountOfTables = tableNameList.size();
         rekTableNameOrder(amountOfTables, tableNameList);
         tableNameOrderRegEx.replace(tableNameOrderRegEx.length()-1, tableNameOrderRegEx.length(), "");
-        tableNameOrderRegEx.append(")");
+        tableNameOrderRegEx.append(')');
         return tableNameOrderRegEx.toString();
     }
 

--- a/src/main/java/sqltoregex/property/regexgenerator/RegExGenerator.java
+++ b/src/main/java/sqltoregex/property/regexgenerator/RegExGenerator.java
@@ -2,5 +2,10 @@ package sqltoregex.property.regexgenerator;
 
 public interface RegExGenerator<T> {
     String generateRegExFor(T wordToFindSynonyms);
+
+    /**
+     * Sets whether there will be an enclosing non capturing group (?: ... ) around the generated regEx.
+     * @param capturingGroup true for capturing group false for non-capturing group
+     */
     void setCapturingGroup(boolean capturingGroup);
 }

--- a/src/main/java/sqltoregex/property/regexgenerator/SpellingMistake.java
+++ b/src/main/java/sqltoregex/property/regexgenerator/SpellingMistake.java
@@ -34,14 +34,13 @@ public class SpellingMistake implements Property<PropertyOption>, RegExGenerator
             throw new IllegalArgumentException("Tablename should not be empty.");
         }
         StringBuilder alternativeWritingStyles = new StringBuilder();
-        if(Boolean.TRUE.equals(this.isCapturingGroup)) alternativeWritingStyles.append("(?:");
-        else alternativeWritingStyles.append("(");
-        alternativeWritingStyles.append(tableName).append("|");
+        alternativeWritingStyles.append(isCapturingGroup ? '(' : "(?:");
+        alternativeWritingStyles.append(tableName).append('|');
         for(int i = 0; i<tableName.length(); i++){
             alternativeWritingStyles.append(tableName, 0, i).append(tableName, i+1, tableName.length()).append("|");
         }
         alternativeWritingStyles.replace(alternativeWritingStyles.length()-1, alternativeWritingStyles.length(), "");
-        alternativeWritingStyles.append(")");
+        alternativeWritingStyles.append(')');
         return alternativeWritingStyles.toString();
     }
 

--- a/src/main/java/sqltoregex/property/regexgenerator/SpellingMistake.java
+++ b/src/main/java/sqltoregex/property/regexgenerator/SpellingMistake.java
@@ -9,7 +9,7 @@ import java.util.*;
  * The OrderRotation class allows creating a RegEx expression that takes into account different spelling variants
  * of a word. It is assumed that omitting a character is "okay".
  * Example:
- * test ↔ (?:test|est|tst|tet|tes)
+ * test ↔ (?:test|est|tst|tet|tes) or (test|est|tst|tet|tes)
  */
 public class SpellingMistake implements Property<PropertyOption>, RegExGenerator<String> {
     private final PropertyOption propertyOption;
@@ -26,18 +26,18 @@ public class SpellingMistake implements Property<PropertyOption>, RegExGenerator
 
     /**
      * Iterates through each letter of the word, storing all spelling variations assuming a letter is forgotten
-     * @param tableName String
+     * @param str String
      * @return creates a regex non-capturing group with all calculated options
      */
-    public String generateRegExFor(String tableName){
-        if(tableName.isEmpty()){
-            throw new IllegalArgumentException("Tablename should not be empty.");
+    public String generateRegExFor(String str){
+        if(str.isEmpty()){
+            throw new IllegalArgumentException("String str should not be empty!");
         }
         StringBuilder alternativeWritingStyles = new StringBuilder();
         alternativeWritingStyles.append(isCapturingGroup ? '(' : "(?:");
-        alternativeWritingStyles.append(tableName).append('|');
-        for(int i = 0; i<tableName.length(); i++){
-            alternativeWritingStyles.append(tableName, 0, i).append(tableName, i+1, tableName.length()).append("|");
+        alternativeWritingStyles.append(str).append('|');
+        for(int i = 0; i<str.length(); i++){
+            alternativeWritingStyles.append(str, 0, i).append(str, i+1, str.length()).append("|");
         }
         alternativeWritingStyles.replace(alternativeWritingStyles.length()-1, alternativeWritingStyles.length(), "");
         alternativeWritingStyles.append(')');
@@ -55,8 +55,7 @@ public class SpellingMistake implements Property<PropertyOption>, RegExGenerator
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof SpellingMistake)) return false;
-        SpellingMistake that = (SpellingMistake) o;
+        if (!(o instanceof SpellingMistake that)) return false;
         return propertyOption == that.propertyOption;
     }
 

--- a/src/main/java/sqltoregex/property/regexgenerator/SpellingMistake.java
+++ b/src/main/java/sqltoregex/property/regexgenerator/SpellingMistake.java
@@ -43,7 +43,10 @@ public class SpellingMistake implements Property<PropertyOption>, RegExGenerator
         alternativeWritingStyles.append(')');
         return alternativeWritingStyles.toString();
     }
-
+    /**
+     * Sets whether there will be an enclosing non capturing group (?: ... ) around the generated regEx.
+     * @param capturingGroup true for capturing group false for non-capturing group
+     */
     @Override
     public void setCapturingGroup(boolean capturingGroup) {
         this.isCapturingGroup = capturingGroup;

--- a/src/main/java/sqltoregex/property/regexgenerator/synonymgenerator/SynonymGenerator.java
+++ b/src/main/java/sqltoregex/property/regexgenerator/synonymgenerator/SynonymGenerator.java
@@ -202,8 +202,9 @@ abstract class SynonymGenerator<A, S> implements Property<A>, RegExGenerator<S> 
 
     /**
      * Sets whether there will be an enclosing non capturing group (?: ... ) around the generated regEx.
-     * @param capturingGroup
+     * @param capturingGroup true for capturing group false for non-capturing group
      */
+    @Override
     public void setCapturingGroup(boolean capturingGroup) {
         this.isCapturingGroup = capturingGroup;
     }

--- a/src/main/java/sqltoregex/property/regexgenerator/synonymgenerator/SynonymGenerator.java
+++ b/src/main/java/sqltoregex/property/regexgenerator/synonymgenerator/SynonymGenerator.java
@@ -80,7 +80,6 @@ abstract class SynonymGenerator<A, S> implements Property<A>, RegExGenerator<S> 
      * @return
      */
     public boolean addSynonymFor(A syn, A synFor){
-        this.graphForSynonymsOfTwoWords = true;
         return addSynonymFor(syn, synFor, DEFAULT_WEIGHT);
     }
 

--- a/src/main/resources/static/config/defaultProperties.xml
+++ b/src/main/resources/static/config/defaultProperties.xml
@@ -31,8 +31,8 @@
             <value>YYYY-MM-DD HH:MM:SS</value>
         </datetimesynonyms>
         <aggregatefunctionlang>
-            <pair>SUM,SUMME</pair>
-            <pair>AVG,MITTELWERT</pair>
+            <pair>SUM;SUMME</pair>
+            <pair>AVG;MITTELWERT</pair>
         </aggregatefunctionlang>
     </synonyms>
 </properties>

--- a/src/test/java/sqltoregex/ConverterManagementTest.java
+++ b/src/test/java/sqltoregex/ConverterManagementTest.java
@@ -8,16 +8,16 @@ class ConverterManagementTest {
     ConverterManagement converterManagement = new ConverterManagement();
 
     @Test
-    void testValidation(){
-        Assertions.assertEquals(true, converterManagement.validate("SELECT col1, col2 FROM table"));
-        Assertions.assertEquals(false, converterManagement.validate("col2 FROM table"));
-    }
-
-    @Test
     void testDeparse() throws JSQLParserException {
         Assertions.assertEquals(
                 "^SELECT col1, col2 FROM table$",
                 converterManagement.deparse("SELECT col1, col2 FROM table")
         );
+    }
+
+    @Test
+    void testValidation() {
+        Assertions.assertEquals(true, converterManagement.validate("SELECT col1, col2 FROM table"));
+        Assertions.assertEquals(false, converterManagement.validate("col2 FROM table"));
     }
 }

--- a/src/test/java/sqltoregex/MultiSqlRegexTest.java
+++ b/src/test/java/sqltoregex/MultiSqlRegexTest.java
@@ -1,35 +1,18 @@
 package sqltoregex;
 
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.web.servlet.MockMvc;
 import sqltoregex.converter.MultiSqlRegex;
 import sqltoregex.converter.SqlRegex;
+
 import java.util.LinkedList;
 import java.util.List;
-import static org.junit.jupiter.api.Assertions.*;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 class MultiSqlRegexTest {
 
     @Test
-    void setListNotEmpty(){
-        SqlRegex testSqlRegexEins = new SqlRegex();
-        SqlRegex testSqlRegexZwei = new SqlRegex();
-        String testInput = "SELECT * FROM table";
-        testSqlRegexEins.setSql(testInput);
-        testSqlRegexZwei.setSql(testInput);
-        List<SqlRegex> sqlregexlist = new LinkedList<>();
-        sqlregexlist.add(testSqlRegexEins);
-        sqlregexlist.add(testSqlRegexZwei);
-
-        MultiSqlRegex multisqlregex = new MultiSqlRegex(sqlregexlist);
-        assertFalse(multisqlregex.getMultiSqlRegex().isEmpty());
-    }
-
-    @Test
-    void checkIfConvertingProduceSomeOutput(){
+    void checkIfConvertingProduceSomeOutput() {
         SqlRegex testSqlRegexEins = new SqlRegex();
         SqlRegex testSqlRegexZwei = new SqlRegex();
         String testInput = "SELECT * FROM table";
@@ -41,8 +24,23 @@ class MultiSqlRegexTest {
 
         MultiSqlRegex multisqlregex = new MultiSqlRegex(sqlregexlist);
         multisqlregex.convert();
-        for (SqlRegex sqlregex : multisqlregex.getMultiSqlRegex()){
+        for (SqlRegex sqlregex : multisqlregex.getMultiSqlRegex()) {
             assertFalse(sqlregex.getRegex().isEmpty());
         }
+    }
+
+    @Test
+    void setListNotEmpty() {
+        SqlRegex testSqlRegexEins = new SqlRegex();
+        SqlRegex testSqlRegexZwei = new SqlRegex();
+        String testInput = "SELECT * FROM table";
+        testSqlRegexEins.setSql(testInput);
+        testSqlRegexZwei.setSql(testInput);
+        List<SqlRegex> sqlregexlist = new LinkedList<>();
+        sqlregexlist.add(testSqlRegexEins);
+        sqlregexlist.add(testSqlRegexZwei);
+
+        MultiSqlRegex multisqlregex = new MultiSqlRegex(sqlregexlist);
+        assertFalse(multisqlregex.getMultiSqlRegex().isEmpty());
     }
 }

--- a/src/test/java/sqltoregex/RestApiControllerTest.java
+++ b/src/test/java/sqltoregex/RestApiControllerTest.java
@@ -5,6 +5,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.web.servlet.MockMvc;
+
 import static org.hamcrest.Matchers.containsString;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;

--- a/src/test/java/sqltoregex/SelectVisitorJoinToWhereTest.java
+++ b/src/test/java/sqltoregex/SelectVisitorJoinToWhereTest.java
@@ -1,18 +1,11 @@
 package sqltoregex;
 
 import net.sf.jsqlparser.JSQLParserException;
-import net.sf.jsqlparser.expression.operators.conditional.AndExpression;
 import net.sf.jsqlparser.parser.CCJSqlParserUtil;
-import net.sf.jsqlparser.statement.select.Join;
-import net.sf.jsqlparser.statement.select.PlainSelect;
 import net.sf.jsqlparser.statement.select.Select;
-import net.sf.jsqlparser.statement.select.SelectVisitorAdapter;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import sqltoregex.visitor.SelectVisitorJoinToWhere;
-
-import java.util.LinkedList;
-import java.util.List;
 
 class SelectVisitorJoinToWhereTest {
 
@@ -22,7 +15,8 @@ class SelectVisitorJoinToWhereTest {
                 "SELECT col1 FROM table1 INNER JOIN table2 ON (col1=col2) AND col3 = col4");
         select.getSelectBody().accept(new SelectVisitorJoinToWhere());
 
-        Assertions.assertEquals("SELECT col1 FROM table1 INNER JOIN table2 WHERE (col1 = col2) AND col3 = col4", select.toString());
+        Assertions.assertEquals("SELECT col1 FROM table1 INNER JOIN table2 WHERE (col1 = col2) AND col3 = col4",
+                                select.toString());
     }
 
     @Test
@@ -31,7 +25,9 @@ class SelectVisitorJoinToWhereTest {
                 "SELECT col1 FROM table1 INNER JOIN table2 ON (col1=col2) AND col3 = col4 WHERE col1=5");
         select.getSelectBody().accept(new SelectVisitorJoinToWhere());
 
-        Assertions.assertEquals("SELECT col1 FROM table1 INNER JOIN table2 WHERE col1 = 5 AND (col1 = col2) AND col3 = col4", select.toString());
+        Assertions.assertEquals(
+                "SELECT col1 FROM table1 INNER JOIN table2 WHERE col1 = 5 AND (col1 = col2) AND col3 = col4",
+                select.toString());
     }
 
 }

--- a/src/test/java/sqltoregex/SqlRegexTest.java
+++ b/src/test/java/sqltoregex/SqlRegexTest.java
@@ -2,31 +2,32 @@ package sqltoregex;
 
 import org.junit.jupiter.api.Test;
 import sqltoregex.converter.SqlRegex;
+
 import static org.junit.jupiter.api.Assertions.*;
 
 class SqlRegexTest {
     @Test
-    void setStatementNotNull(){
-        SqlRegex sqlregex = new SqlRegex("SELECT * FROM table");
-        assertEquals("SELECT * FROM table", sqlregex.getSql());
+    void initSqlRegexGetRegex() {
+        SqlRegex sqlregex = new SqlRegex();
+        assertTrue(sqlregex.getRegex().isEmpty());
     }
 
     @Test
-    void initSqlRegexGetSql(){
+    void initSqlRegexGetSql() {
         SqlRegex sqlregex = new SqlRegex();
         assertTrue(sqlregex.getSql().isEmpty());
     }
 
     @Test
-    void setEmptySQL(){
+    void setEmptySQL() {
         SqlRegex sqlregex = new SqlRegex();
         Exception exception = assertThrows(NullPointerException.class, () -> sqlregex.setSql(""));
         assertEquals("SQL-Input-String should have more characters than null.", exception.getMessage());
     }
 
     @Test
-    void initSqlRegexGetRegex(){
-        SqlRegex sqlregex = new SqlRegex();
-        assertTrue(sqlregex.getRegex().isEmpty());
+    void setStatementNotNull() {
+        SqlRegex sqlregex = new SqlRegex("SELECT * FROM table");
+        assertEquals("SELECT * FROM table", sqlregex.getSql());
     }
 }

--- a/src/test/java/sqltoregex/SqlToRegexControllerTest.java
+++ b/src/test/java/sqltoregex/SqlToRegexControllerTest.java
@@ -24,18 +24,31 @@ class SqlToRegexControllerTest {
     MockMvc mvc;
 
     @Test
-    void testExampleSite() throws Exception {
-        mvc.perform(get("/examples").contentType(MediaType.TEXT_HTML)).andExpect(status().isOk());
-    }
-
-    @Test
     void testAboutSite() throws Exception {
         mvc.perform(get("/about").contentType(MediaType.TEXT_HTML)).andExpect(status().isOk());
     }
 
     @Test
-    void testStartSite() throws Exception {
-        mvc.perform(get("/").contentType(MediaType.TEXT_HTML)).andExpect(status().isOk());
+    void testConvertingAsset() throws Exception {
+        mvc.perform(MockMvcRequestBuilders
+                            .post("/convert")
+                            .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                            .content(EntityUtils.toString(new UrlEncodedFormEntity(Arrays.asList(
+                                    new BasicNameValuePair("spellings", PropertyOption.KEYWORDSPELLING.toString()),
+                                    new BasicNameValuePair("orders", PropertyOption.TABLENAMEORDER.toString()),
+                                    new BasicNameValuePair("dateFormats", "yyyy-MM-dd"),
+                                    new BasicNameValuePair("timeFormats", "HH:MM:SS"),
+                                    new BasicNameValuePair("dateTimeFormats", "YYYY-MM-DD HH:MM:SS"),
+                                    new BasicNameValuePair("sql", "SELECT *"),
+                                    new BasicNameValuePair("aggregateFunctionLang", "Mittelwert; AVG")
+                            ))))
+                            .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void testExampleSite() throws Exception {
+        mvc.perform(get("/examples").contentType(MediaType.TEXT_HTML)).andExpect(status().isOk());
     }
 
     @Test
@@ -49,11 +62,6 @@ class SqlToRegexControllerTest {
     }
 
     @Test
-    void testVisualizationSite() throws Exception {
-        mvc.perform(get("/visualization").contentType(MediaType.TEXT_HTML)).andExpect(status().isOk());
-    }
-
-    @Test
     void testRobotsSite() throws Exception {
         mvc.perform(get("/robots.txt").contentType(MediaType.TEXT_HTML)).andExpect(status().isOk());
     }
@@ -64,20 +72,12 @@ class SqlToRegexControllerTest {
     }
 
     @Test
-    void testConvertingAsset() throws Exception {
-        mvc.perform(MockMvcRequestBuilders
-                .post("/convert")
-                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
-                            .content(EntityUtils.toString(new UrlEncodedFormEntity(Arrays.asList(
-                                    new BasicNameValuePair("spellings", PropertyOption.KEYWORDSPELLING.toString()),
-                                    new BasicNameValuePair("orders", PropertyOption.TABLENAMEORDER.toString()),
-                                    new BasicNameValuePair("dateFormats", "yyyy-MM-dd"),
-                                    new BasicNameValuePair("timeFormats", "HH:MM:SS"),
-                                    new BasicNameValuePair("dateTimeFormats", "YYYY-MM-DD HH:MM:SS"),
-                                    new BasicNameValuePair("sql" , "SELECT *"),
-                                    new BasicNameValuePair("aggregateFunctionLang", "Mittelwert; AVG")
-                                    ))))
-                .accept(MediaType.APPLICATION_JSON))
-                .andExpect(status().isOk());
+    void testStartSite() throws Exception {
+        mvc.perform(get("/").contentType(MediaType.TEXT_HTML)).andExpect(status().isOk());
+    }
+
+    @Test
+    void testVisualizationSite() throws Exception {
+        mvc.perform(get("/visualization").contentType(MediaType.TEXT_HTML)).andExpect(status().isOk());
     }
 }

--- a/src/test/java/sqltoregex/SqlToRegexControllerTest.java
+++ b/src/test/java/sqltoregex/SqlToRegexControllerTest.java
@@ -1,5 +1,8 @@
 package sqltoregex;
 
+import org.apache.http.client.entity.UrlEncodedFormEntity;
+import org.apache.http.message.BasicNameValuePair;
+import org.apache.http.util.EntityUtils;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -7,6 +10,9 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import sqltoregex.property.PropertyOption;
+
+import java.util.Arrays;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -61,6 +67,16 @@ class SqlToRegexControllerTest {
     void testConvertingAsset() throws Exception {
         mvc.perform(MockMvcRequestBuilders
                 .post("/convert")
+                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                            .content(EntityUtils.toString(new UrlEncodedFormEntity(Arrays.asList(
+                                    new BasicNameValuePair("spellings", PropertyOption.KEYWORDSPELLING.toString()),
+                                    new BasicNameValuePair("orders", PropertyOption.TABLENAMEORDER.toString()),
+                                    new BasicNameValuePair("dateFormats", "yyyy-MM-dd"),
+                                    new BasicNameValuePair("timeFormats", "HH:MM:SS"),
+                                    new BasicNameValuePair("dateTimeFormats", "YYYY-MM-DD HH:MM:SS"),
+                                    new BasicNameValuePair("sql" , "SELECT *"),
+                                    new BasicNameValuePair("aggregateFunctionLang", "Mittelwert; AVG")
+                                    ))))
                 .accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk());
     }

--- a/src/test/java/sqltoregex/TestMain.java
+++ b/src/test/java/sqltoregex/TestMain.java
@@ -1,4 +1,5 @@
 package sqltoregex;
+
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -21,15 +22,15 @@ class TestMain {
 //    private RestApiController restApiController;
 
     @Test
-    void main(){
-        assertDoesNotThrow(() -> SqlToRegexApplication.main(new String[] {}));
-    }
-
-    @Test
     void contextLoads() {
         assertNotNull(myErrorController);
         assertNotNull(resourceConfig);
         assertNotNull(sql2RegexController);
 //        assertNotNull(restApiController);
+    }
+
+    @Test
+    void main() {
+        assertDoesNotThrow(() -> SqlToRegexApplication.main(new String[]{}));
     }
 }

--- a/src/test/java/sqltoregex/property/PropertyManagerTest.java
+++ b/src/test/java/sqltoregex/property/PropertyManagerTest.java
@@ -2,6 +2,7 @@ package sqltoregex.property;
 
 import org.junit.jupiter.api.*;
 import org.xml.sax.SAXException;
+import sqltoregex.property.regexgenerator.synonymgenerator.DateAndTimeFormatSynonymGenerator;
 
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.xpath.XPathExpressionException;
@@ -50,55 +51,8 @@ class PropertyManagerTest {
                 "DATETIMESYNONYMS",
                 "AGGREGATEFUNCTIONLANG"
          );
-        System.out.println(propertyOptionSet);
         for(String str : propertyOptionWhichHaveBeenSet){
             Assertions.assertTrue(propertyOptionSet.toString().contains(str));
         }
-    }
-
-    @Test
-    void testUserConfigurations() {
-        spellings.add(PropertyOption.KEYWORDSPELLING);
-        orders.add(PropertyOption.COLUMNNAMEORDER);
-        dateFormats.add(new SimpleDateFormat("yyyy-MM-dd"));
-        aggregateFunctionLang.add("SUM,SUMME");
-        PropertyForm propertyForm = new PropertyForm(
-                spellings, orders, dateFormats, timeFormats, dateTimeFormats, aggregateFunctionLang, sql
-        );
-
-        PropertyMapBuilder propertyMapBuilder = new PropertyMapBuilder();
-        propertyMapBuilder.withPropertyOption(PropertyOption.KEYWORDSPELLING);
-        propertyMapBuilder.withPropertyOption(PropertyOption.COLUMNNAMEORDER);
-
-        Set<String> dateSynonymsSet = new HashSet<>();
-        dateSynonymsSet.add("yyyy-MM-dd");
-        propertyMapBuilder.withStringSet(dateSynonymsSet, PropertyOption.DATESYNONYMS);
-        propertyMapBuilder.withStringSet(aggregateFunctionLang, PropertyOption.AGGREGATEFUNCTIONLANG);
-
-        Assertions.assertEquals(propertyMapBuilder.build(), propertyManager.parseUserOptionsInput(propertyForm));
-    }
-
-    @Test
-    void testUserConfigurationsWhenEverythingIsDisabeld() {
-        PropertyForm propertyForm = new PropertyForm(spellings, orders, dateFormats, timeFormats, dateTimeFormats, aggregateFunctionLang, sql);
-        PropertyMapBuilder propertyMapBuilder = new PropertyMapBuilder();
-        Assertions.assertEquals(propertyMapBuilder.build(), propertyManager.parseUserOptionsInput(propertyForm));
-    }
-
-    @Test
-    void testAggregateFunctionLangInPropertyManager() {
-        aggregateFunctionLang.add("SUMME,SUM");
-        aggregateFunctionLang.add("MITTELWERT,AVG");
-        PropertyForm propertyForm = new PropertyForm(spellings, orders, dateFormats, timeFormats, dateTimeFormats, aggregateFunctionLang, sql);
-        PropertyMapBuilder propertyMapBuilder = new PropertyMapBuilder();
-        propertyMapBuilder.withStringSet(aggregateFunctionLang, PropertyOption.AGGREGATEFUNCTIONLANG).build();
-        Assertions.assertEquals(propertyMapBuilder.build(), propertyManager.parseUserOptionsInput(propertyForm));
-
-        Set<?> getSettingsSet = propertyManager.parseUserOptionsInput(propertyForm).get(PropertyOption.AGGREGATEFUNCTIONLANG).getSettings();
-        Assertions.assertEquals(2, getSettingsSet.size());
-        Assertions.assertTrue(getSettingsSet.toString().contains("SUMME"));
-        Assertions.assertTrue(getSettingsSet.toString().contains("SUM"));
-        Assertions.assertTrue(getSettingsSet.toString().contains("AVG"));
-        Assertions.assertTrue(getSettingsSet.toString().contains("MITTELWERT"));
     }
 }

--- a/src/test/java/sqltoregex/property/PropertyManagerTest.java
+++ b/src/test/java/sqltoregex/property/PropertyManagerTest.java
@@ -1,14 +1,17 @@
 package sqltoregex.property;
 
-import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.xml.sax.SAXException;
-import sqltoregex.property.regexgenerator.synonymgenerator.DateAndTimeFormatSynonymGenerator;
 
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.xpath.XPathExpressionException;
 import java.io.IOException;
 import java.text.SimpleDateFormat;
-import java.util.*;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
 class PropertyManagerTest {
     static PropertyManager propertyManager;
@@ -20,6 +23,11 @@ class PropertyManagerTest {
     static Set<String> aggregateFunctionLang;
     static String sql;
 
+    @BeforeEach
+    void beforeEach() throws XPathExpressionException, ParserConfigurationException, IOException, SAXException {
+        this.resetSets();
+    }
+
     void resetSets() throws XPathExpressionException, ParserConfigurationException, IOException, SAXException {
         propertyManager = new PropertyManager();
         spellings = new HashSet<>();
@@ -29,11 +37,6 @@ class PropertyManagerTest {
         dateTimeFormats = new HashSet<>();
         aggregateFunctionLang = new HashSet<>();
         sql = "SELECT * FROM test";
-    }
-
-    @BeforeEach
-    void beforeEach() throws XPathExpressionException, ParserConfigurationException, IOException, SAXException {
-        this.resetSets();
     }
 
     @Test
@@ -50,8 +53,8 @@ class PropertyManagerTest {
                 "TIMESYNONYMS",
                 "DATETIMESYNONYMS",
                 "AGGREGATEFUNCTIONLANG"
-         );
-        for(String str : propertyOptionWhichHaveBeenSet){
+        );
+        for (String str : propertyOptionWhichHaveBeenSet) {
             Assertions.assertTrue(propertyOptionSet.toString().contains(str));
         }
     }

--- a/src/test/java/sqltoregex/property/PropertyManagerTest.java
+++ b/src/test/java/sqltoregex/property/PropertyManagerTest.java
@@ -30,10 +30,13 @@ class PropertyManagerTest {
         sql = "SELECT * FROM test";
     }
 
-    @Test
-    void testLoadDefaultProperties() throws ParserConfigurationException, IOException, SAXException, XPathExpressionException {
+    @BeforeEach
+    void beforeEach() throws XPathExpressionException, ParserConfigurationException, IOException, SAXException {
         this.resetSets();
-        PropertyManager propertyManager = new PropertyManager();
+    }
+
+    @Test
+    void testLoadDefaultProperties() {
         Set<PropertyOption> propertyOptionSet = propertyManager.readPropertyOptions();
         List<String> propertyOptionWhichHaveBeenSet = List.of(
                 "KEYWORDSPELLING",
@@ -54,8 +57,7 @@ class PropertyManagerTest {
     }
 
     @Test
-    void testUserConfigurations() throws XPathExpressionException, ParserConfigurationException, IOException, SAXException {
-        resetSets();
+    void testUserConfigurations() {
         spellings.add(PropertyOption.KEYWORDSPELLING);
         orders.add(PropertyOption.COLUMNNAMEORDER);
         dateFormats.add(new SimpleDateFormat("yyyy-MM-dd"));
@@ -77,16 +79,14 @@ class PropertyManagerTest {
     }
 
     @Test
-    void testUserConfigurationsWhenEverythingIsDisabeld() throws XPathExpressionException, ParserConfigurationException, IOException, SAXException {
-        resetSets();
+    void testUserConfigurationsWhenEverythingIsDisabeld() {
         PropertyForm propertyForm = new PropertyForm(spellings, orders, dateFormats, timeFormats, dateTimeFormats, aggregateFunctionLang, sql);
         PropertyMapBuilder propertyMapBuilder = new PropertyMapBuilder();
         Assertions.assertEquals(propertyMapBuilder.build(), propertyManager.parseUserOptionsInput(propertyForm));
     }
 
     @Test
-    void testAggregateFunctionLangInPropertyManager() throws XPathExpressionException, ParserConfigurationException, IOException, SAXException {
-        resetSets();
+    void testAggregateFunctionLangInPropertyManager() {
         aggregateFunctionLang.add("SUMME,SUM");
         aggregateFunctionLang.add("MITTELWERT,AVG");
         PropertyForm propertyForm = new PropertyForm(spellings, orders, dateFormats, timeFormats, dateTimeFormats, aggregateFunctionLang, sql);

--- a/src/test/java/sqltoregex/property/PropertyManagerTest.java
+++ b/src/test/java/sqltoregex/property/PropertyManagerTest.java
@@ -67,13 +67,13 @@ class PropertyManagerTest {
         );
 
         PropertyMapBuilder propertyMapBuilder = new PropertyMapBuilder();
-        propertyMapBuilder.with(PropertyOption.KEYWORDSPELLING);
-        propertyMapBuilder.with(PropertyOption.COLUMNNAMEORDER);
+        propertyMapBuilder.withPropertyOption(PropertyOption.KEYWORDSPELLING);
+        propertyMapBuilder.withPropertyOption(PropertyOption.COLUMNNAMEORDER);
 
         Set<String> dateSynonymsSet = new HashSet<>();
         dateSynonymsSet.add("yyyy-MM-dd");
-        propertyMapBuilder.with(dateSynonymsSet, PropertyOption.DATESYNONYMS);
-        propertyMapBuilder.with(aggregateFunctionLang, PropertyOption.AGGREGATEFUNCTIONLANG);
+        propertyMapBuilder.withStringSet(dateSynonymsSet, PropertyOption.DATESYNONYMS);
+        propertyMapBuilder.withStringSet(aggregateFunctionLang, PropertyOption.AGGREGATEFUNCTIONLANG);
 
         Assertions.assertEquals(propertyMapBuilder.build(), propertyManager.parseUserOptionsInput(propertyForm));
     }
@@ -91,7 +91,7 @@ class PropertyManagerTest {
         aggregateFunctionLang.add("MITTELWERT,AVG");
         PropertyForm propertyForm = new PropertyForm(spellings, orders, dateFormats, timeFormats, dateTimeFormats, aggregateFunctionLang, sql);
         PropertyMapBuilder propertyMapBuilder = new PropertyMapBuilder();
-        propertyMapBuilder.with(aggregateFunctionLang, PropertyOption.AGGREGATEFUNCTIONLANG).build();
+        propertyMapBuilder.withStringSet(aggregateFunctionLang, PropertyOption.AGGREGATEFUNCTIONLANG).build();
         Assertions.assertEquals(propertyMapBuilder.build(), propertyManager.parseUserOptionsInput(propertyForm));
 
         Set<?> getSettingsSet = propertyManager.parseUserOptionsInput(propertyForm).get(PropertyOption.AGGREGATEFUNCTIONLANG).getSettings();

--- a/src/test/java/sqltoregex/property/PropertyMapBuilderTest.java
+++ b/src/test/java/sqltoregex/property/PropertyMapBuilderTest.java
@@ -79,9 +79,6 @@ class PropertyMapBuilderTest {
         builder.withStringSet(Collections.emptySet(), PropertyOption.AGGREGATEFUNCTIONLANG);
         Map<PropertyOption, Property<?>> map = builder.build();
         Assertions.assertEquals(0, map.size());
-        Assertions.assertTrue(map.containsKey(PropertyOption.AGGREGATEFUNCTIONLANG));
-        Assertions.assertTrue(
-                map.containsValue(new DateAndTimeFormatSynonymGenerator(PropertyOption.AGGREGATEFUNCTIONLANG)));
     }
 
     @Test

--- a/src/test/java/sqltoregex/property/PropertyMapBuilderTest.java
+++ b/src/test/java/sqltoregex/property/PropertyMapBuilderTest.java
@@ -15,21 +15,108 @@ class PropertyMapBuilderTest {
 
     PropertyMapBuilder builder;
 
+    @Test
+    void OrderAndSpellingWithSameProp() {
+        builder.withPropertyOption(PropertyOption.COLUMNNAMEORDER);
+        builder.withPropertyOption(PropertyOption.COLUMNNAMESPELLING);
+        OrderRotation orderRotation = (OrderRotation) builder.build().get(PropertyOption.COLUMNNAMEORDER);
+        Assertions.assertEquals(new SpellingMistake(PropertyOption.COLUMNNAMESPELLING),
+                                orderRotation.getSpellingMistake());
+    }
+
     @BeforeEach
     void beforeEach() {
         builder = new PropertyMapBuilder();
     }
 
     @Test
-    void builderStartsWithEmptyMap() {
-        Assertions.assertEquals(Collections.emptyMap(), builder.build());
+    void buildWith2EqualObjects() {
+        builder.withPropertyOption(PropertyOption.COLUMNNAMEORDER);
+        builder.withPropertyOption(PropertyOption.COLUMNNAMEORDER);
+        Map<PropertyOption, Property<?>> map = builder.build();
+        Assertions.assertEquals(1, map.size());
     }
 
     @Test
-    void buildWithEmptySetOfPropertyOption(){
+    void buildWithColumnNameOrder() {
+        builder.withPropertyOption(PropertyOption.COLUMNNAMEORDER);
+        Map<PropertyOption, Property<?>> map = builder.build();
+        Assertions.assertEquals(1, map.size());
+        Assertions.assertTrue(map.containsKey(PropertyOption.COLUMNNAMEORDER));
+        Assertions.assertTrue(map.containsValue(new OrderRotation(PropertyOption.COLUMNNAMEORDER)));
+    }
+
+    @Test
+    void buildWithDateSynonyms() {
+        final String FORMAT = "yyyy-MM-dd";
+        builder.withSimpleDateFormatSet(new HashSet<>(List.of(new SimpleDateFormat(FORMAT))),
+                                        PropertyOption.DATESYNONYMS);
+        Map<PropertyOption, Property<?>> map = builder.build();
+        Assertions.assertEquals(1, map.size());
+        DateAndTimeFormatSynonymGenerator dateAndTimeFormatSynonymGenerator = new DateAndTimeFormatSynonymGenerator(
+                PropertyOption.DATESYNONYMS);
+        dateAndTimeFormatSynonymGenerator.addSynonym(new SimpleDateFormat(FORMAT));
+        Assertions.assertTrue(map.containsKey(PropertyOption.DATESYNONYMS));
+        Assertions.assertTrue(map.containsValue(dateAndTimeFormatSynonymGenerator));
+    }
+
+    @Test
+    void buildWithDateTimeSynonyms() {
+        final String FORMAT = "yyyy-MM-dd hh:mm:ss";
+        builder.withSimpleDateFormatSet(new HashSet<>(List.of(new SimpleDateFormat(FORMAT))),
+                                        PropertyOption.DATETIMESYNONYMS);
+        Map<PropertyOption, Property<?>> map = builder.build();
+        Assertions.assertEquals(1, map.size());
+        Assertions.assertTrue(map.containsKey(PropertyOption.DATETIMESYNONYMS));
+        DateAndTimeFormatSynonymGenerator dateAndTimeFormatSynonymGenerator = new DateAndTimeFormatSynonymGenerator(
+                PropertyOption.DATETIMESYNONYMS);
+        dateAndTimeFormatSynonymGenerator.addSynonym(new SimpleDateFormat(FORMAT));
+        Assertions.assertTrue(map.containsValue(dateAndTimeFormatSynonymGenerator));
+    }
+
+    @Test
+    void buildWithEmptyAggregateFunctionLang() {
+        builder.withStringSet(Collections.emptySet(), PropertyOption.AGGREGATEFUNCTIONLANG);
+        Map<PropertyOption, Property<?>> map = builder.build();
+        Assertions.assertEquals(0, map.size());
+        Assertions.assertTrue(map.containsKey(PropertyOption.AGGREGATEFUNCTIONLANG));
+        Assertions.assertTrue(
+                map.containsValue(new DateAndTimeFormatSynonymGenerator(PropertyOption.AGGREGATEFUNCTIONLANG)));
+    }
+
+    @Test
+    void buildWithEmptyDateSynonyms() {
+        builder.withSimpleDateFormatSet(Collections.emptySet(), PropertyOption.DATESYNONYMS);
+        Map<PropertyOption, Property<?>> map = builder.build();
+        Assertions.assertEquals(1, map.size());
+        Assertions.assertTrue(map.containsKey(PropertyOption.DATESYNONYMS));
+        Assertions.assertTrue(map.containsValue(new DateAndTimeFormatSynonymGenerator(PropertyOption.DATESYNONYMS)));
+    }
+
+    @Test
+    void buildWithEmptyDateTimeSynonyms() {
+        builder.withSimpleDateFormatSet(Collections.emptySet(), PropertyOption.DATETIMESYNONYMS);
+        Map<PropertyOption, Property<?>> map = builder.build();
+        Assertions.assertEquals(1, map.size());
+        Assertions.assertTrue(map.containsKey(PropertyOption.DATETIMESYNONYMS));
+        Assertions.assertTrue(
+                map.containsValue(new DateAndTimeFormatSynonymGenerator(PropertyOption.DATETIMESYNONYMS)));
+    }
+
+    @Test
+    void buildWithEmptySetOfPropertyOption() {
         builder.withPropertyOptionSet(new HashSet<>());
         Map<PropertyOption, Property<?>> map = builder.build();
         Assertions.assertEquals(0, map.size());
+    }
+
+    @Test
+    void buildWithEmptyTimeSynonyms() {
+        builder.withSimpleDateFormatSet(Collections.emptySet(), PropertyOption.TIMESYNONYMS);
+        Map<PropertyOption, Property<?>> map = builder.build();
+        Assertions.assertEquals(1, map.size());
+        Assertions.assertTrue(map.containsKey(PropertyOption.TIMESYNONYMS));
+        Assertions.assertTrue(map.containsValue(new DateAndTimeFormatSynonymGenerator(PropertyOption.TIMESYNONYMS)));
     }
 
     @Test
@@ -51,47 +138,6 @@ class PropertyMapBuilderTest {
     }
 
     @Test
-    void buildWithColumnNameOrder() {
-        builder.withPropertyOption(PropertyOption.COLUMNNAMEORDER);
-        Map<PropertyOption, Property<?>> map = builder.build();
-        Assertions.assertEquals(1, map.size());
-        Assertions.assertTrue(map.containsKey(PropertyOption.COLUMNNAMEORDER));
-        Assertions.assertTrue(map.containsValue(new OrderRotation(PropertyOption.COLUMNNAMEORDER)));
-    }
-
-    @Test
-    void buildWithEmptyDateSynonyms() {
-        builder.withSimpleDateFormatSet(Collections.emptySet(), PropertyOption.DATESYNONYMS);
-        Map<PropertyOption, Property<?>> map = builder.build();
-        Assertions.assertEquals(1, map.size());
-        Assertions.assertTrue(map.containsKey(PropertyOption.DATESYNONYMS));
-        Assertions.assertTrue(map.containsValue(new DateAndTimeFormatSynonymGenerator(PropertyOption.DATESYNONYMS)));
-    }
-
-    @Test
-    void buildWithDateSynonyms() {
-        final String FORMAT = "yyyy-MM-dd";
-        builder.withSimpleDateFormatSet(new HashSet<>(List.of(new SimpleDateFormat(FORMAT))),
-                                        PropertyOption.DATESYNONYMS);
-        Map<PropertyOption, Property<?>> map = builder.build();
-        Assertions.assertEquals(1, map.size());
-        DateAndTimeFormatSynonymGenerator dateAndTimeFormatSynonymGenerator = new DateAndTimeFormatSynonymGenerator(
-                PropertyOption.DATESYNONYMS);
-        dateAndTimeFormatSynonymGenerator.addSynonym(new SimpleDateFormat(FORMAT));
-        Assertions.assertTrue(map.containsKey(PropertyOption.DATESYNONYMS));
-        Assertions.assertTrue(map.containsValue(dateAndTimeFormatSynonymGenerator));
-    }
-
-    @Test
-    void buildWithEmptyTimeSynonyms() {
-        builder.withSimpleDateFormatSet(Collections.emptySet(), PropertyOption.TIMESYNONYMS);
-        Map<PropertyOption, Property<?>> map = builder.build();
-        Assertions.assertEquals(1, map.size());
-        Assertions.assertTrue(map.containsKey(PropertyOption.TIMESYNONYMS));
-        Assertions.assertTrue(map.containsValue(new DateAndTimeFormatSynonymGenerator(PropertyOption.TIMESYNONYMS)));
-    }
-
-    @Test
     void buildWithTimeSynonyms() {
         final String FORMAT = "hh:mm:ss";
         builder.withSimpleDateFormatSet(new HashSet<>(List.of(new SimpleDateFormat(FORMAT))),
@@ -106,54 +152,8 @@ class PropertyMapBuilderTest {
     }
 
     @Test
-    void buildWithEmptyDateTimeSynonyms() {
-        builder.withSimpleDateFormatSet(Collections.emptySet(), PropertyOption.DATETIMESYNONYMS);
-        Map<PropertyOption, Property<?>> map = builder.build();
-        Assertions.assertEquals(1, map.size());
-        Assertions.assertTrue(map.containsKey(PropertyOption.DATETIMESYNONYMS));
-        Assertions.assertTrue(
-                map.containsValue(new DateAndTimeFormatSynonymGenerator(PropertyOption.DATETIMESYNONYMS)));
-    }
-
-    @Test
-    void buildWithDateTimeSynonyms() {
-        final String FORMAT = "yyyy-MM-dd hh:mm:ss";
-        builder.withSimpleDateFormatSet(new HashSet<>(List.of(new SimpleDateFormat(FORMAT))),
-                                        PropertyOption.DATETIMESYNONYMS);
-        Map<PropertyOption, Property<?>> map = builder.build();
-        Assertions.assertEquals(1, map.size());
-        Assertions.assertTrue(map.containsKey(PropertyOption.DATETIMESYNONYMS));
-        DateAndTimeFormatSynonymGenerator dateAndTimeFormatSynonymGenerator = new DateAndTimeFormatSynonymGenerator(
-                PropertyOption.DATETIMESYNONYMS);
-        dateAndTimeFormatSynonymGenerator.addSynonym(new SimpleDateFormat(FORMAT));
-        Assertions.assertTrue(map.containsValue(dateAndTimeFormatSynonymGenerator));
-    }
-
-    @Test
-    void buildWith2EqualObjects() {
-        builder.withPropertyOption(PropertyOption.COLUMNNAMEORDER);
-        builder.withPropertyOption(PropertyOption.COLUMNNAMEORDER);
-        Map<PropertyOption, Property<?>> map = builder.build();
-        Assertions.assertEquals(1, map.size());
-    }
-
-    @Test
-    void OrderAndSpellingWithSameProp() {
-        builder.withPropertyOption(PropertyOption.COLUMNNAMEORDER);
-        builder.withPropertyOption(PropertyOption.COLUMNNAMESPELLING);
-        OrderRotation orderRotation = (OrderRotation) builder.build().get(PropertyOption.COLUMNNAMEORDER);
-        Assertions.assertEquals(new SpellingMistake(PropertyOption.COLUMNNAMESPELLING),
-                                orderRotation.getSpellingMistake());
-    }
-
-    @Test
-    void buildWithEmptyAggregateFunctionLang() {
-        builder.withStringSet(Collections.emptySet(), PropertyOption.AGGREGATEFUNCTIONLANG);
-        Map<PropertyOption, Property<?>> map = builder.build();
-        Assertions.assertEquals(0, map.size());
-        Assertions.assertTrue(map.containsKey(PropertyOption.AGGREGATEFUNCTIONLANG));
-        Assertions.assertTrue(
-                map.containsValue(new DateAndTimeFormatSynonymGenerator(PropertyOption.AGGREGATEFUNCTIONLANG)));
+    void builderStartsWithEmptyMap() {
+        Assertions.assertEquals(Collections.emptyMap(), builder.build());
     }
 
     @Test
@@ -167,7 +167,8 @@ class PropertyMapBuilderTest {
         Map<PropertyOption, Property<?>> map = builder.build();
         Assertions.assertEquals(1, map.size());
         Assertions.assertTrue(map.containsKey(PropertyOption.AGGREGATEFUNCTIONLANG));
-        StringSynonymGenerator stringSynonymGenerator = new StringSynonymGenerator(PropertyOption.AGGREGATEFUNCTIONLANG);
+        StringSynonymGenerator stringSynonymGenerator = new StringSynonymGenerator(
+                PropertyOption.AGGREGATEFUNCTIONLANG);
         stringSynonymGenerator.addSynonymFor(PAIR_ONE.split(";")[0], PAIR_ONE.split(";")[1]);
         stringSynonymGenerator.addSynonymFor(PAIR_TWO.split(";")[0], PAIR_TWO.split(";")[1]);
         Assertions.assertTrue(map.containsValue(stringSynonymGenerator));

--- a/src/test/java/sqltoregex/property/PropertyMapBuilderTest.java
+++ b/src/test/java/sqltoregex/property/PropertyMapBuilderTest.java
@@ -6,26 +6,34 @@ import org.junit.jupiter.api.Test;
 import sqltoregex.property.regexgenerator.OrderRotation;
 import sqltoregex.property.regexgenerator.SpellingMistake;
 import sqltoregex.property.regexgenerator.synonymgenerator.DateAndTimeFormatSynonymGenerator;
+import sqltoregex.property.regexgenerator.synonymgenerator.StringSynonymGenerator;
 
-import java.util.Collections;
-import java.util.Map;
+import java.text.SimpleDateFormat;
+import java.util.*;
 
 class PropertyMapBuilderTest {
 
     PropertyMapBuilder builder;
 
     @BeforeEach
-    void beforeEach(){
+    void beforeEach() {
         builder = new PropertyMapBuilder();
     }
 
     @Test
-    void builderStartsWithEmptyMap(){
+    void builderStartsWithEmptyMap() {
         Assertions.assertEquals(Collections.emptyMap(), builder.build());
     }
 
     @Test
-    void buildWithKeyWordSpelling(){
+    void buildWithEmptySetOfPropertyOption(){
+        builder.withPropertyOptionSet(new HashSet<>());
+        Map<PropertyOption, Property<?>> map = builder.build();
+        Assertions.assertEquals(0, map.size());
+    }
+
+    @Test
+    void buildWithKeyWordSpelling() {
         builder.withPropertyOption(PropertyOption.KEYWORDSPELLING);
         Map<PropertyOption, Property<?>> map = builder.build();
         Assertions.assertEquals(1, map.size());
@@ -34,7 +42,7 @@ class PropertyMapBuilderTest {
     }
 
     @Test
-    void buildWithTableNameOrder(){
+    void buildWithTableNameOrder() {
         builder.withPropertyOption(PropertyOption.TABLENAMEORDER);
         Map<PropertyOption, Property<?>> map = builder.build();
         Assertions.assertEquals(1, map.size());
@@ -43,7 +51,7 @@ class PropertyMapBuilderTest {
     }
 
     @Test
-    void buildWithColumnNameOrder(){
+    void buildWithColumnNameOrder() {
         builder.withPropertyOption(PropertyOption.COLUMNNAMEORDER);
         Map<PropertyOption, Property<?>> map = builder.build();
         Assertions.assertEquals(1, map.size());
@@ -52,7 +60,7 @@ class PropertyMapBuilderTest {
     }
 
     @Test
-    void buildWithDateSynonyms(){
+    void buildWithEmptyDateSynonyms() {
         builder.withSimpleDateFormatSet(Collections.emptySet(), PropertyOption.DATESYNONYMS);
         Map<PropertyOption, Property<?>> map = builder.build();
         Assertions.assertEquals(1, map.size());
@@ -61,7 +69,21 @@ class PropertyMapBuilderTest {
     }
 
     @Test
-    void buildWithTimeSynonyms(){
+    void buildWithDateSynonyms() {
+        final String FORMAT = "yyyy-MM-dd";
+        builder.withSimpleDateFormatSet(new HashSet<>(List.of(new SimpleDateFormat(FORMAT))),
+                                        PropertyOption.DATESYNONYMS);
+        Map<PropertyOption, Property<?>> map = builder.build();
+        Assertions.assertEquals(1, map.size());
+        DateAndTimeFormatSynonymGenerator dateAndTimeFormatSynonymGenerator = new DateAndTimeFormatSynonymGenerator(
+                PropertyOption.DATESYNONYMS);
+        dateAndTimeFormatSynonymGenerator.addSynonym(new SimpleDateFormat(FORMAT));
+        Assertions.assertTrue(map.containsKey(PropertyOption.DATESYNONYMS));
+        Assertions.assertTrue(map.containsValue(dateAndTimeFormatSynonymGenerator));
+    }
+
+    @Test
+    void buildWithEmptyTimeSynonyms() {
         builder.withSimpleDateFormatSet(Collections.emptySet(), PropertyOption.TIMESYNONYMS);
         Map<PropertyOption, Property<?>> map = builder.build();
         Assertions.assertEquals(1, map.size());
@@ -70,16 +92,45 @@ class PropertyMapBuilderTest {
     }
 
     @Test
-    void buildWithDateTimeSynonyms(){
+    void buildWithTimeSynonyms() {
+        final String FORMAT = "hh:mm:ss";
+        builder.withSimpleDateFormatSet(new HashSet<>(List.of(new SimpleDateFormat(FORMAT))),
+                                        PropertyOption.TIMESYNONYMS);
+        Map<PropertyOption, Property<?>> map = builder.build();
+        Assertions.assertEquals(1, map.size());
+        DateAndTimeFormatSynonymGenerator dateAndTimeFormatSynonymGenerator = new DateAndTimeFormatSynonymGenerator(
+                PropertyOption.TIMESYNONYMS);
+        dateAndTimeFormatSynonymGenerator.addSynonym(new SimpleDateFormat(FORMAT));
+        Assertions.assertTrue(map.containsKey(PropertyOption.TIMESYNONYMS));
+        Assertions.assertTrue(map.containsValue(dateAndTimeFormatSynonymGenerator));
+    }
+
+    @Test
+    void buildWithEmptyDateTimeSynonyms() {
         builder.withSimpleDateFormatSet(Collections.emptySet(), PropertyOption.DATETIMESYNONYMS);
         Map<PropertyOption, Property<?>> map = builder.build();
         Assertions.assertEquals(1, map.size());
         Assertions.assertTrue(map.containsKey(PropertyOption.DATETIMESYNONYMS));
-        Assertions.assertTrue(map.containsValue(new DateAndTimeFormatSynonymGenerator(PropertyOption.DATETIMESYNONYMS)));
+        Assertions.assertTrue(
+                map.containsValue(new DateAndTimeFormatSynonymGenerator(PropertyOption.DATETIMESYNONYMS)));
     }
 
     @Test
-    void buildWith2EqualObjects(){
+    void buildWithDateTimeSynonyms() {
+        final String FORMAT = "yyyy-MM-dd hh:mm:ss";
+        builder.withSimpleDateFormatSet(new HashSet<>(List.of(new SimpleDateFormat(FORMAT))),
+                                        PropertyOption.DATETIMESYNONYMS);
+        Map<PropertyOption, Property<?>> map = builder.build();
+        Assertions.assertEquals(1, map.size());
+        Assertions.assertTrue(map.containsKey(PropertyOption.DATETIMESYNONYMS));
+        DateAndTimeFormatSynonymGenerator dateAndTimeFormatSynonymGenerator = new DateAndTimeFormatSynonymGenerator(
+                PropertyOption.DATETIMESYNONYMS);
+        dateAndTimeFormatSynonymGenerator.addSynonym(new SimpleDateFormat(FORMAT));
+        Assertions.assertTrue(map.containsValue(dateAndTimeFormatSynonymGenerator));
+    }
+
+    @Test
+    void buildWith2EqualObjects() {
         builder.withPropertyOption(PropertyOption.COLUMNNAMEORDER);
         builder.withPropertyOption(PropertyOption.COLUMNNAMEORDER);
         Map<PropertyOption, Property<?>> map = builder.build();
@@ -87,10 +138,38 @@ class PropertyMapBuilderTest {
     }
 
     @Test
-    void OrderAndSpellingWithSameProp(){
+    void OrderAndSpellingWithSameProp() {
         builder.withPropertyOption(PropertyOption.COLUMNNAMEORDER);
         builder.withPropertyOption(PropertyOption.COLUMNNAMESPELLING);
         OrderRotation orderRotation = (OrderRotation) builder.build().get(PropertyOption.COLUMNNAMEORDER);
-        Assertions.assertEquals(new SpellingMistake(PropertyOption.COLUMNNAMESPELLING), orderRotation.getSpellingMistake());
+        Assertions.assertEquals(new SpellingMistake(PropertyOption.COLUMNNAMESPELLING),
+                                orderRotation.getSpellingMistake());
+    }
+
+    @Test
+    void buildWithEmptyAggregateFunctionLang() {
+        builder.withStringSet(Collections.emptySet(), PropertyOption.AGGREGATEFUNCTIONLANG);
+        Map<PropertyOption, Property<?>> map = builder.build();
+        Assertions.assertEquals(0, map.size());
+        Assertions.assertTrue(map.containsKey(PropertyOption.AGGREGATEFUNCTIONLANG));
+        Assertions.assertTrue(
+                map.containsValue(new DateAndTimeFormatSynonymGenerator(PropertyOption.AGGREGATEFUNCTIONLANG)));
+    }
+
+    @Test
+    void testAggregateFunctionLangInPropertyManager() {
+        String PAIR_ONE = "SUMME;SUM";
+        String PAIR_TWO = "MITTELWERT;AVG";
+        Set<String> aggregateFunctionLang = new HashSet<String>();
+        aggregateFunctionLang.add(PAIR_ONE);
+        aggregateFunctionLang.add(PAIR_TWO);
+        builder.withStringSet(aggregateFunctionLang, PropertyOption.AGGREGATEFUNCTIONLANG);
+        Map<PropertyOption, Property<?>> map = builder.build();
+        Assertions.assertEquals(1, map.size());
+        Assertions.assertTrue(map.containsKey(PropertyOption.AGGREGATEFUNCTIONLANG));
+        StringSynonymGenerator stringSynonymGenerator = new StringSynonymGenerator(PropertyOption.AGGREGATEFUNCTIONLANG);
+        stringSynonymGenerator.addSynonymFor(PAIR_ONE.split(";")[0], PAIR_ONE.split(";")[1]);
+        stringSynonymGenerator.addSynonymFor(PAIR_TWO.split(";")[0], PAIR_TWO.split(";")[1]);
+        Assertions.assertTrue(map.containsValue(stringSynonymGenerator));
     }
 }

--- a/src/test/java/sqltoregex/property/PropertyMapBuilderTest.java
+++ b/src/test/java/sqltoregex/property/PropertyMapBuilderTest.java
@@ -1,14 +1,11 @@
 package sqltoregex.property;
 
-import org.apache.commons.lang3.tuple.ImmutablePair;
-import org.apache.commons.lang3.tuple.Pair;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import sqltoregex.property.regexgenerator.OrderRotation;
 import sqltoregex.property.regexgenerator.SpellingMistake;
 import sqltoregex.property.regexgenerator.synonymgenerator.DateAndTimeFormatSynonymGenerator;
-import sqltoregex.property.regexgenerator.synonymgenerator.StringSynonymGenerator;
 
 import java.util.Collections;
 import java.util.Map;
@@ -29,7 +26,7 @@ class PropertyMapBuilderTest {
 
     @Test
     void buildWithKeyWordSpelling(){
-        builder.with(PropertyOption.KEYWORDSPELLING);
+        builder.withPropertyOption(PropertyOption.KEYWORDSPELLING);
         Map<PropertyOption, Property<?>> map = builder.build();
         Assertions.assertEquals(1, map.size());
         Assertions.assertTrue(map.containsKey(PropertyOption.KEYWORDSPELLING));
@@ -38,7 +35,7 @@ class PropertyMapBuilderTest {
 
     @Test
     void buildWithTableNameOrder(){
-        builder.with(PropertyOption.TABLENAMEORDER);
+        builder.withPropertyOption(PropertyOption.TABLENAMEORDER);
         Map<PropertyOption, Property<?>> map = builder.build();
         Assertions.assertEquals(1, map.size());
         Assertions.assertTrue(map.containsKey(PropertyOption.TABLENAMEORDER));
@@ -47,7 +44,7 @@ class PropertyMapBuilderTest {
 
     @Test
     void buildWithColumnNameOrder(){
-        builder.with(PropertyOption.COLUMNNAMEORDER);
+        builder.withPropertyOption(PropertyOption.COLUMNNAMEORDER);
         Map<PropertyOption, Property<?>> map = builder.build();
         Assertions.assertEquals(1, map.size());
         Assertions.assertTrue(map.containsKey(PropertyOption.COLUMNNAMEORDER));
@@ -56,7 +53,7 @@ class PropertyMapBuilderTest {
 
     @Test
     void buildWithDateSynonyms(){
-        builder.with(Collections.emptySet(), PropertyOption.DATESYNONYMS);
+        builder.withSimpleDateFormatSet(Collections.emptySet(), PropertyOption.DATESYNONYMS);
         Map<PropertyOption, Property<?>> map = builder.build();
         Assertions.assertEquals(1, map.size());
         Assertions.assertTrue(map.containsKey(PropertyOption.DATESYNONYMS));
@@ -65,7 +62,7 @@ class PropertyMapBuilderTest {
 
     @Test
     void buildWithTimeSynonyms(){
-        builder.with(Collections.emptySet(), PropertyOption.TIMESYNONYMS);
+        builder.withSimpleDateFormatSet(Collections.emptySet(), PropertyOption.TIMESYNONYMS);
         Map<PropertyOption, Property<?>> map = builder.build();
         Assertions.assertEquals(1, map.size());
         Assertions.assertTrue(map.containsKey(PropertyOption.TIMESYNONYMS));
@@ -74,7 +71,7 @@ class PropertyMapBuilderTest {
 
     @Test
     void buildWithDateTimeSynonyms(){
-        builder.with(Collections.emptySet(), PropertyOption.DATETIMESYNONYMS);
+        builder.withSimpleDateFormatSet(Collections.emptySet(), PropertyOption.DATETIMESYNONYMS);
         Map<PropertyOption, Property<?>> map = builder.build();
         Assertions.assertEquals(1, map.size());
         Assertions.assertTrue(map.containsKey(PropertyOption.DATETIMESYNONYMS));
@@ -83,16 +80,16 @@ class PropertyMapBuilderTest {
 
     @Test
     void buildWith2EqualObjects(){
-        builder.with(PropertyOption.COLUMNNAMEORDER);
-        builder.with(PropertyOption.COLUMNNAMEORDER);
+        builder.withPropertyOption(PropertyOption.COLUMNNAMEORDER);
+        builder.withPropertyOption(PropertyOption.COLUMNNAMEORDER);
         Map<PropertyOption, Property<?>> map = builder.build();
         Assertions.assertEquals(1, map.size());
     }
 
     @Test
     void OrderAndSpellingWithSameProp(){
-        builder.with(PropertyOption.COLUMNNAMEORDER);
-        builder.with(PropertyOption.COLUMNNAMESPELLING);
+        builder.withPropertyOption(PropertyOption.COLUMNNAMEORDER);
+        builder.withPropertyOption(PropertyOption.COLUMNNAMESPELLING);
         OrderRotation orderRotation = (OrderRotation) builder.build().get(PropertyOption.COLUMNNAMEORDER);
         Assertions.assertEquals(new SpellingMistake(PropertyOption.COLUMNNAMESPELLING), orderRotation.getSpellingMistake());
     }

--- a/src/test/java/sqltoregex/property/UserPropertyTest.java
+++ b/src/test/java/sqltoregex/property/UserPropertyTest.java
@@ -10,19 +10,20 @@ import java.util.Map;
 class UserPropertyTest {
 
     @Test
-    void onlyOneInstance(){
+    void MapNotMutable() {
         Map<PropertyOption, Property<?>> map = new HashMap<>();
-        UserProperty userProperty1 =  UserProperty.getInstance(map);
-        UserProperty userProperty2 = UserProperty.getInstance(map);
-        Assertions.assertEquals(userProperty1, userProperty2);
+        UserProperty userProperty1 = UserProperty.getInstance(map);
+        Assertions.assertThrows(UnsupportedOperationException.class, () -> userProperty1.propertyMap.putAll(map));
+        OrderRotation orderRotation = new OrderRotation(PropertyOption.DEFAULT);
+        Assertions.assertThrows(UnsupportedOperationException.class,
+                                () -> userProperty1.propertyMap.put(PropertyOption.COLUMNNAMEORDER, orderRotation));
     }
 
     @Test
-    void MapNotMutable(){
+    void onlyOneInstance() {
         Map<PropertyOption, Property<?>> map = new HashMap<>();
-        UserProperty userProperty1 =  UserProperty.getInstance(map);
-        Assertions.assertThrows(UnsupportedOperationException.class, () -> userProperty1.propertyMap.putAll(map));
-        OrderRotation orderRotation = new OrderRotation(PropertyOption.DEFAULT);
-        Assertions.assertThrows(UnsupportedOperationException.class, () -> userProperty1.propertyMap.put(PropertyOption.COLUMNNAMEORDER, orderRotation));
+        UserProperty userProperty1 = UserProperty.getInstance(map);
+        UserProperty userProperty2 = UserProperty.getInstance(map);
+        Assertions.assertEquals(userProperty1, userProperty2);
     }
 }

--- a/src/test/java/sqltoregex/property/regexgenerator/OrderRotationTest.java
+++ b/src/test/java/sqltoregex/property/regexgenerator/OrderRotationTest.java
@@ -3,7 +3,6 @@ package sqltoregex.property.regexgenerator;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import sqltoregex.property.PropertyOption;
-import sqltoregex.property.regexgenerator.OrderRotation;
 
 import java.util.Arrays;
 import java.util.List;
@@ -14,7 +13,53 @@ class OrderRotationTest {
     List<String> testListTwo = List.of("table1");
 
     @Test
-    void testOrderRotationWithoutAlternativeWritingStyles(){
+    void equals() {
+        OrderRotation orderRotation1 = new OrderRotation(PropertyOption.DEFAULT);
+        OrderRotation orderRotation2 = new OrderRotation(PropertyOption.DEFAULT);
+        Assertions.assertEquals(orderRotation1, orderRotation2);
+        Assertions.assertNotEquals(orderRotation1, new OrderRotation(PropertyOption.COLUMNNAMEORDER));
+        orderRotation2.setSpellingMistake(new SpellingMistake(PropertyOption.DEFAULT));
+        Assertions.assertNotEquals(orderRotation1, orderRotation2);
+    }
+
+    @Test
+    void getSetting() {
+        OrderRotation orderRotation = new OrderRotation(PropertyOption.COLUMNNAMEORDER);
+        Assertions.assertEquals(1, orderRotation.getSettings().size());
+        Assertions.assertTrue(orderRotation.getSettings().contains(PropertyOption.COLUMNNAMEORDER));
+    }
+
+    @Test
+    void testOrderRotationWithAlternativeWritingStyles() {
+        SpellingMistake spellingMistake = new SpellingMistake(PropertyOption.DEFAULT);
+        spellingMistake.setCapturingGroup(true);
+        orderRotation.setSpellingMistake(spellingMistake);
+        orderRotation.setCapturingGroup(true);
+        Assertions.assertEquals(
+                "((table1|able1|tble1|tale1|tabe1|tabl1|table)\\s*,\\s*(table2|able2|tble2|tale2|tabe2|tabl2|table)|" +
+                        "(table2|able2|tble2|tale2|tabe2|tabl2|table)\\s*,\\s*" +
+                        "(table1|able1|tble1|tale1|tabe1|tabl1|table))",
+                orderRotation.generateRegExFor(testListOne)
+        );
+    }
+
+    @Test
+    void testOrderRotationWithAlternativeWritingStylesWithCapturingGroup() {
+        SpellingMistake spellingMistake = new SpellingMistake(PropertyOption.DEFAULT);
+        spellingMistake.setCapturingGroup(false);
+        orderRotation.setSpellingMistake(spellingMistake);
+        orderRotation.setCapturingGroup(false);
+        Assertions.assertEquals(
+                "(?:(?:table1|able1|tble1|tale1|tabe1|tabl1|table)\\s*,\\s*" +
+                        "(?:table2|able2|tble2|tale2|tabe2|tabl2|table)|" +
+                        "(?:table2|able2|tble2|tale2|tabe2|tabl2|table)\\s*,\\s*" +
+                        "(?:table1|able1|tble1|tale1|tabe1|tabl1|table))",
+                orderRotation.generateRegExFor(testListOne)
+        );
+    }
+
+    @Test
+    void testOrderRotationWithoutAlternativeWritingStyles() {
         orderRotation.setCapturingGroup(true);
         Assertions.assertEquals(
                 "(table1\\s*,\\s*table2|table2\\s*,\\s*table1)",
@@ -23,16 +68,12 @@ class OrderRotationTest {
     }
 
     @Test
-    void testOrderRotationWithoutAlternativeWritingStylesWithCapturingGroup(){
-        orderRotation.setCapturingGroup(false);
-        Assertions.assertEquals(
-                "(?:table1\\s*,\\s*table2|table2\\s*,\\s*table1)",
-                orderRotation.generateRegExFor(testListOne)
-        );
+    void testOrderRotationWithoutAlternativeWritingStylesNullArguments() {
+        Assertions.assertThrows(IllegalArgumentException.class, () -> orderRotation.generateRegExFor(null));
     }
 
     @Test
-    void testOrderRotationWithoutAlternativeWritingStylesOneElement(){
+    void testOrderRotationWithoutAlternativeWritingStylesOneElement() {
         orderRotation.setCapturingGroup(true);
         Assertions.assertEquals(
                 "(table1)",
@@ -41,7 +82,7 @@ class OrderRotationTest {
     }
 
     @Test
-    void testOrderRotationWithoutAlternativeWritingStylesOneElementWithCapturingGroup(){
+    void testOrderRotationWithoutAlternativeWritingStylesOneElementWithCapturingGroup() {
         orderRotation.setCapturingGroup(false);
         Assertions.assertEquals(
                 "(?:table1)",
@@ -50,48 +91,11 @@ class OrderRotationTest {
     }
 
     @Test
-    void testOrderRotationWithoutAlternativeWritingStylesNullArguments(){
-        Assertions.assertThrows(IllegalArgumentException.class, () -> orderRotation.generateRegExFor(null));
-    }
-
-    @Test
-    void testOrderRotationWithAlternativeWritingStyles(){
-        SpellingMistake spellingMistake = new SpellingMistake(PropertyOption.DEFAULT);
-        spellingMistake.setCapturingGroup(true);
-        orderRotation.setSpellingMistake(spellingMistake);
-        orderRotation.setCapturingGroup(true);
-        Assertions.assertEquals(
-                "((table1|able1|tble1|tale1|tabe1|tabl1|table)\\s*,\\s*(table2|able2|tble2|tale2|tabe2|tabl2|table)|(table2|able2|tble2|tale2|tabe2|tabl2|table)\\s*,\\s*(table1|able1|tble1|tale1|tabe1|tabl1|table))",
-                orderRotation.generateRegExFor(testListOne)
-        );
-    }
-
-    @Test
-    void testOrderRotationWithAlternativeWritingStylesWithCapturingGroup(){
-        SpellingMistake spellingMistake = new SpellingMistake(PropertyOption.DEFAULT);
-        spellingMistake.setCapturingGroup(false);
-        orderRotation.setSpellingMistake(spellingMistake);
+    void testOrderRotationWithoutAlternativeWritingStylesWithCapturingGroup() {
         orderRotation.setCapturingGroup(false);
         Assertions.assertEquals(
-                "(?:(?:table1|able1|tble1|tale1|tabe1|tabl1|table)\\s*,\\s*(?:table2|able2|tble2|tale2|tabe2|tabl2|table)|(?:table2|able2|tble2|tale2|tabe2|tabl2|table)\\s*,\\s*(?:table1|able1|tble1|tale1|tabe1|tabl1|table))",
+                "(?:table1\\s*,\\s*table2|table2\\s*,\\s*table1)",
                 orderRotation.generateRegExFor(testListOne)
         );
-    }
-
-    @Test
-    void getSetting(){
-        OrderRotation orderRotation = new OrderRotation(PropertyOption.COLUMNNAMEORDER);
-        Assertions.assertEquals(1, orderRotation.getSettings().size());
-        Assertions.assertTrue(orderRotation.getSettings().contains(PropertyOption.COLUMNNAMEORDER));
-    }
-
-    @Test
-    void equals(){
-        OrderRotation orderRotation1 = new OrderRotation(PropertyOption.DEFAULT);
-        OrderRotation orderRotation2 = new OrderRotation(PropertyOption.DEFAULT);
-        Assertions.assertEquals(orderRotation1, orderRotation2);
-        Assertions.assertNotEquals(orderRotation1, new OrderRotation(PropertyOption.COLUMNNAMEORDER));
-        orderRotation2.setSpellingMistake(new SpellingMistake(PropertyOption.DEFAULT));
-        Assertions.assertNotEquals(orderRotation1, orderRotation2);
     }
 }

--- a/src/test/java/sqltoregex/property/regexgenerator/OrderRotationTest.java
+++ b/src/test/java/sqltoregex/property/regexgenerator/OrderRotationTest.java
@@ -15,7 +15,7 @@ class OrderRotationTest {
 
     @Test
     void testOrderRotationWithoutAlternativeWritingStyles(){
-        orderRotation.setCapturingGroup(false);
+        orderRotation.setCapturingGroup(true);
         Assertions.assertEquals(
                 "(table1\\s*,\\s*table2|table2\\s*,\\s*table1)",
                 orderRotation.generateRegExFor(testListOne)
@@ -24,7 +24,7 @@ class OrderRotationTest {
 
     @Test
     void testOrderRotationWithoutAlternativeWritingStylesWithCapturingGroup(){
-        orderRotation.setCapturingGroup(true);
+        orderRotation.setCapturingGroup(false);
         Assertions.assertEquals(
                 "(?:table1\\s*,\\s*table2|table2\\s*,\\s*table1)",
                 orderRotation.generateRegExFor(testListOne)
@@ -33,7 +33,7 @@ class OrderRotationTest {
 
     @Test
     void testOrderRotationWithoutAlternativeWritingStylesOneElement(){
-        orderRotation.setCapturingGroup(false);
+        orderRotation.setCapturingGroup(true);
         Assertions.assertEquals(
                 "(table1)",
                 orderRotation.generateRegExFor(testListTwo)
@@ -42,7 +42,7 @@ class OrderRotationTest {
 
     @Test
     void testOrderRotationWithoutAlternativeWritingStylesOneElementWithCapturingGroup(){
-        orderRotation.setCapturingGroup(true);
+        orderRotation.setCapturingGroup(false);
         Assertions.assertEquals(
                 "(?:table1)",
                 orderRotation.generateRegExFor(testListTwo)
@@ -56,7 +56,10 @@ class OrderRotationTest {
 
     @Test
     void testOrderRotationWithAlternativeWritingStyles(){
-        orderRotation.setSpellingMistake(new SpellingMistake(PropertyOption.DEFAULT));
+        SpellingMistake spellingMistake = new SpellingMistake(PropertyOption.DEFAULT);
+        spellingMistake.setCapturingGroup(true);
+        orderRotation.setSpellingMistake(spellingMistake);
+        orderRotation.setCapturingGroup(true);
         Assertions.assertEquals(
                 "((table1|able1|tble1|tale1|tabe1|tabl1|table)\\s*,\\s*(table2|able2|tble2|tale2|tabe2|tabl2|table)|(table2|able2|tble2|tale2|tabe2|tabl2|table)\\s*,\\s*(table1|able1|tble1|tale1|tabe1|tabl1|table))",
                 orderRotation.generateRegExFor(testListOne)
@@ -66,9 +69,9 @@ class OrderRotationTest {
     @Test
     void testOrderRotationWithAlternativeWritingStylesWithCapturingGroup(){
         SpellingMistake spellingMistake = new SpellingMistake(PropertyOption.DEFAULT);
-        spellingMistake.setCapturingGroup(true);
+        spellingMistake.setCapturingGroup(false);
         orderRotation.setSpellingMistake(spellingMistake);
-        orderRotation.setCapturingGroup(true);
+        orderRotation.setCapturingGroup(false);
         Assertions.assertEquals(
                 "(?:(?:table1|able1|tble1|tale1|tabe1|tabl1|table)\\s*,\\s*(?:table2|able2|tble2|tale2|tabe2|tabl2|table)|(?:table2|able2|tble2|tale2|tabe2|tabl2|table)\\s*,\\s*(?:table1|able1|tble1|tale1|tabe1|tabl1|table))",
                 orderRotation.generateRegExFor(testListOne)

--- a/src/test/java/sqltoregex/property/regexgenerator/SpellingMistakeTest.java
+++ b/src/test/java/sqltoregex/property/regexgenerator/SpellingMistakeTest.java
@@ -9,16 +9,16 @@ class SpellingMistakeTest {
     public SpellingMistake spellingMistake = new SpellingMistake(PropertyOption.DEFAULT);
 
     @Test
-    void testSpellingMistakeOutputWithCapturingGroup(){
+    void testSpellingMistakeOutputWithNonCapturingGroup(){
         String input = "test";
-        spellingMistake.setCapturingGroup(true);
         String alternativeStyles = spellingMistake.generateRegExFor(input);
         Assertions.assertEquals("(?:test|est|tst|tet|tes)", alternativeStyles);
     }
 
     @Test
-    void testSpellingMistakeOutputWithoutCapturingGroup(){
+    void testSpellingMistakeOutputWitCapturingGroup(){
         String input = "test";
+        spellingMistake.setCapturingGroup(true);
         String alternativeStyles = spellingMistake.generateRegExFor(input);
         Assertions.assertEquals("(test|est|tst|tet|tes)", alternativeStyles);
     }

--- a/src/test/java/sqltoregex/property/regexgenerator/SpellingMistakeTest.java
+++ b/src/test/java/sqltoregex/property/regexgenerator/SpellingMistakeTest.java
@@ -3,28 +3,24 @@ package sqltoregex.property.regexgenerator;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import sqltoregex.property.PropertyOption;
-import sqltoregex.property.regexgenerator.SpellingMistake;
 
 class SpellingMistakeTest {
     public SpellingMistake spellingMistake = new SpellingMistake(PropertyOption.DEFAULT);
 
     @Test
-    void testSpellingMistakeOutputWithNonCapturingGroup(){
-        String input = "test";
-        String alternativeStyles = spellingMistake.generateRegExFor(input);
-        Assertions.assertEquals("(?:test|est|tst|tet|tes)", alternativeStyles);
+    void equals() {
+        Assertions.assertEquals(new SpellingMistake(PropertyOption.DEFAULT),
+                                new SpellingMistake(PropertyOption.DEFAULT));
     }
 
     @Test
-    void testSpellingMistakeOutputWitCapturingGroup(){
-        String input = "test";
-        spellingMistake.setCapturingGroup(true);
-        String alternativeStyles = spellingMistake.generateRegExFor(input);
-        Assertions.assertEquals("(test|est|tst|tet|tes)", alternativeStyles);
+    void testGetProperty() {
+        Assertions.assertEquals(1, spellingMistake.getSettings().size());
+        Assertions.assertTrue(spellingMistake.getSettings().contains(PropertyOption.DEFAULT));
     }
 
     @Test
-    void testSpellingMistakeOutputEmptyTableName(){
+    void testSpellingMistakeOutputEmptyTableName() {
         String input = "";
         Assertions.assertThrows(IllegalArgumentException.class, () -> {
             String alternativeStyles = spellingMistake.generateRegExFor(input);
@@ -32,13 +28,17 @@ class SpellingMistakeTest {
     }
 
     @Test
-    void testGetProperty(){
-        Assertions.assertEquals(1, spellingMistake.getSettings().size());
-        Assertions.assertTrue(spellingMistake.getSettings().contains(PropertyOption.DEFAULT));
+    void testSpellingMistakeOutputWitCapturingGroup() {
+        String input = "test";
+        spellingMistake.setCapturingGroup(true);
+        String alternativeStyles = spellingMistake.generateRegExFor(input);
+        Assertions.assertEquals("(test|est|tst|tet|tes)", alternativeStyles);
     }
 
     @Test
-    void equals(){
-        Assertions.assertEquals(new SpellingMistake(PropertyOption.DEFAULT), new SpellingMistake(PropertyOption.DEFAULT));
+    void testSpellingMistakeOutputWithNonCapturingGroup() {
+        String input = "test";
+        String alternativeStyles = spellingMistake.generateRegExFor(input);
+        Assertions.assertEquals("(?:test|est|tst|tet|tes)", alternativeStyles);
     }
 }

--- a/src/test/java/sqltoregex/property/regexgenerator/synonymgenerator/DateAndTimeFormatSynonymGeneratorTest.java
+++ b/src/test/java/sqltoregex/property/regexgenerator/synonymgenerator/DateAndTimeFormatSynonymGeneratorTest.java
@@ -12,7 +12,7 @@ import java.text.SimpleDateFormat;
 class DateAndTimeFormatSynonymGeneratorTest {
 
 
-    private DateAndTimeFormatSynonymGenerator getSynonymManagerForDates(){
+    private DateAndTimeFormatSynonymGenerator getSynonymManagerForDates() {
         DateAndTimeFormatSynonymGenerator dateAndTimeSynonymManager = new DateAndTimeFormatSynonymGenerator(
                 PropertyOption.DEFAULT);
         dateAndTimeSynonymManager.addSynonym(new SimpleDateFormat("yyyy-MM-dd"));
@@ -20,42 +20,50 @@ class DateAndTimeFormatSynonymGeneratorTest {
         return dateAndTimeSynonymManager;
     }
 
-    private DateAndTimeFormatSynonymGenerator getSynonymManagerForTimes(){
-        DateAndTimeFormatSynonymGenerator dateAndTimeSynonymManager = new DateAndTimeFormatSynonymGenerator(PropertyOption.DEFAULT);
+    private DateAndTimeFormatSynonymGenerator getSynonymManagerForTimes() {
+        DateAndTimeFormatSynonymGenerator dateAndTimeSynonymManager = new DateAndTimeFormatSynonymGenerator(
+                PropertyOption.DEFAULT);
         dateAndTimeSynonymManager.addSynonym(new SimpleDateFormat("HH:mm:ss"));
         dateAndTimeSynonymManager.addSynonym(new SimpleDateFormat("H:m:s"));
         return dateAndTimeSynonymManager;
     }
 
-    private DateAndTimeFormatSynonymGenerator getSynonymManagerForTimestamps(){
-        DateAndTimeFormatSynonymGenerator dateAndTimeSynonymManager = new DateAndTimeFormatSynonymGenerator(PropertyOption.DEFAULT);
+    private DateAndTimeFormatSynonymGenerator getSynonymManagerForTimestamps() {
+        DateAndTimeFormatSynonymGenerator dateAndTimeSynonymManager = new DateAndTimeFormatSynonymGenerator(
+                PropertyOption.DEFAULT);
         dateAndTimeSynonymManager.addSynonym(new SimpleDateFormat("yyyy-MM-dd HH:mm:ss"));
         dateAndTimeSynonymManager.addSynonym(new SimpleDateFormat("yyyy-MM-dd H:m:s"));
         return dateAndTimeSynonymManager;
     }
 
     @Test
-    void queryNotExistingSynonym(){
-        DateAndTimeFormatSynonymGenerator dateAndTimeSynonymManager = new DateAndTimeFormatSynonymGenerator(PropertyOption.DEFAULT);
-        Assertions.assertEquals("(?:2012-5-6)", dateAndTimeSynonymManager.generateRegExFor(new DateValue("'2012-5-6'")));
-        Assertions.assertEquals("(?:2012-05-06)", dateAndTimeSynonymManager.generateRegExFor(new DateValue("'2012-05-06'")));
-    }
-
-    @Test
-    void queryExistingDateSynonym(){
+    void queryExistingDateSynonym() {
         DateAndTimeFormatSynonymGenerator dateAndTimeSynonymManager = getSynonymManagerForDates();
-        Assertions.assertEquals("(?:2012-05-06|12-05-06)", dateAndTimeSynonymManager.generateRegExFor(new DateValue("'2012-05-06'")));
+        Assertions.assertEquals("(?:2012-05-06|12-05-06)",
+                                dateAndTimeSynonymManager.generateRegExFor(new DateValue("'2012-05-06'")));
     }
 
     @Test
-    void queryExistingTimeSynonym(){
+    void queryExistingTimeSynonym() {
         DateAndTimeFormatSynonymGenerator dateAndTimeSynonymManager = getSynonymManagerForTimes();
-        Assertions.assertEquals("(?:01:02:03|1:2:3)", dateAndTimeSynonymManager.generateRegExFor(new TimeValue("'01:02:03'")));
+        Assertions.assertEquals("(?:01:02:03|1:2:3)",
+                                dateAndTimeSynonymManager.generateRegExFor(new TimeValue("'01:02:03'")));
     }
 
     @Test
-    void queryExistingTimestampSynonym(){
+    void queryExistingTimestampSynonym() {
         DateAndTimeFormatSynonymGenerator dateAndTimeSynonymManager = getSynonymManagerForTimestamps();
-        Assertions.assertEquals("(?:2012-05-06 01:02:03|2012-05-06 1:2:3)", dateAndTimeSynonymManager.generateRegExFor(new TimestampValue("2012-05-06 01:02:03")));
+        Assertions.assertEquals("(?:2012-05-06 01:02:03|2012-05-06 1:2:3)",
+                                dateAndTimeSynonymManager.generateRegExFor(new TimestampValue("2012-05-06 01:02:03")));
+    }
+
+    @Test
+    void queryNotExistingSynonym() {
+        DateAndTimeFormatSynonymGenerator dateAndTimeSynonymManager = new DateAndTimeFormatSynonymGenerator(
+                PropertyOption.DEFAULT);
+        Assertions.assertEquals("(?:2012-5-6)",
+                                dateAndTimeSynonymManager.generateRegExFor(new DateValue("'2012-5-6'")));
+        Assertions.assertEquals("(?:2012-05-06)",
+                                dateAndTimeSynonymManager.generateRegExFor(new DateValue("'2012-05-06'")));
     }
 }

--- a/src/test/java/sqltoregex/property/regexgenerator/synonymgenerator/StringSynonymGeneratorTest.java
+++ b/src/test/java/sqltoregex/property/regexgenerator/synonymgenerator/StringSynonymGeneratorTest.java
@@ -10,7 +10,7 @@ class StringSynonymGeneratorTest {
     private StringSynonymGenerator defaultSynonymManager;
 
     @BeforeEach
-    void beforeAll(){
+    void beforeAll() {
         this.defaultSynonymManager = new StringSynonymGenerator(PropertyOption.DEFAULT);
         defaultSynonymManager.addSynonym("witzig");
         defaultSynonymManager.addSynonym("komisch");
@@ -19,14 +19,14 @@ class StringSynonymGeneratorTest {
     }
 
     @Test
-    void queryNotExistingSynonym(){
-        Assertions.assertEquals("(traurig)", defaultSynonymManager.generateRegExFor("traurig"));
-    }
-
-    @Test
-    void queryExistingSynonym(){
+    void queryExistingSynonym() {
         Assertions.assertEquals("(witzig|ulkig|komisch)", defaultSynonymManager.generateRegExFor("witzig"));
         Assertions.assertEquals("(ulkig|komisch|witzig)", defaultSynonymManager.generateRegExFor("ulkig"));
         Assertions.assertEquals("(komisch|ulkig|witzig)", defaultSynonymManager.generateRegExFor("komisch"));
+    }
+
+    @Test
+    void queryNotExistingSynonym() {
+        Assertions.assertEquals("(traurig)", defaultSynonymManager.generateRegExFor("traurig"));
     }
 }

--- a/src/test/java/sqltoregex/property/regexgenerator/synonymgenerator/SynonymGeneratorTest.java
+++ b/src/test/java/sqltoregex/property/regexgenerator/synonymgenerator/SynonymGeneratorTest.java
@@ -1,6 +1,5 @@
 package sqltoregex.property.regexgenerator.synonymgenerator;
 
-import org.junit.Assert;
 import org.junit.jupiter.api.*;
 import sqltoregex.property.PropertyOption;
 
@@ -10,39 +9,40 @@ import java.util.Set;
 
 /**
  * weighted Graph testing ist not possible due to lack of equals and hashcode method overriding in Framework
- *     @Test
- *     void add2VerticesImplicitWeightedEdge(){
- *         stringSynonymGenerator.addSynonym("Mittelwert");
- *         stringSynonymGenerator.addSynonym("AVG", 2L);
- *         Assertions.assertEquals(2, stringSynonymGenerator.synonymsGraph.edgeSet().toArray()[0]);
- *     }
  *
- *     @Test
- *     void add2VerticesAndExplicitWeightedEdge(){
- *         stringSynonymGenerator.addSynonymFor("Mittelwert", "AVG", 2L);
- *         Assertions.assertEquals(2, stringSynonymGenerator.synonymsGraph.vertexSet().size());
- *         Assertions.assertEquals(1, stringSynonymGenerator.synonymsGraph.edgeSet().size());
- *     }
+ * @Test void add2VerticesImplicitWeightedEdge(){
+ * stringSynonymGenerator.addSynonym("Mittelwert");
+ * stringSynonymGenerator.addSynonym("AVG", 2L);
+ * Assertions.assertEquals(2, stringSynonymGenerator.synonymsGraph.edgeSet().toArray()[0]);
+ * }
+ * @Test void add2VerticesAndExplicitWeightedEdge(){
+ * stringSynonymGenerator.addSynonymFor("Mittelwert", "AVG", 2L);
+ * Assertions.assertEquals(2, stringSynonymGenerator.synonymsGraph.vertexSet().size());
+ * Assertions.assertEquals(1, stringSynonymGenerator.synonymsGraph.edgeSet().size());
+ * }
  */
 @TestMethodOrder(MethodOrderer.MethodName.class)
 class SynonymGeneratorTest {
 
     private StringSynonymGenerator stringSynonymGenerator;
 
-    @BeforeEach
-    void beforeEach(){
-        stringSynonymGenerator = new StringSynonymGenerator(PropertyOption.DEFAULT);
-    }
-
     @Test
-    void add2VerticesAndExplicitEdge(){
+    void add2VerticesAndExplicitEdge() {
         stringSynonymGenerator.addSynonymFor("Mittelwert", "AVG");
         Assertions.assertEquals(2, stringSynonymGenerator.synonymsGraph.vertexSet().size());
         Assertions.assertEquals(1, stringSynonymGenerator.synonymsGraph.edgeSet().size());
     }
 
     @Test
-    void add3VerticesAndExplicitEdges(){
+    void add2VerticesAndImplicitEdge() {
+        stringSynonymGenerator.addSynonym("Mittelwert");
+        stringSynonymGenerator.addSynonym("AVG");
+        Assertions.assertEquals(2, stringSynonymGenerator.synonymsGraph.vertexSet().size());
+        Assertions.assertEquals(1, stringSynonymGenerator.synonymsGraph.edgeSet().size());
+    }
+
+    @Test
+    void add3VerticesAndExplicitEdges() {
         stringSynonymGenerator.addSynonymFor("Mittelwert", "AVG");
         stringSynonymGenerator.addSynonymFor("Average", "AVG");
         Assertions.assertEquals(3, stringSynonymGenerator.synonymsGraph.vertexSet().size());
@@ -50,15 +50,7 @@ class SynonymGeneratorTest {
     }
 
     @Test
-    void add2VerticesAndImplicitEdge(){
-        stringSynonymGenerator.addSynonym("Mittelwert");
-        stringSynonymGenerator.addSynonym("AVG");
-        Assertions.assertEquals(2, stringSynonymGenerator.synonymsGraph.vertexSet().size());
-        Assertions.assertEquals(1, stringSynonymGenerator.synonymsGraph.edgeSet().size());
-    }
-
-    @Test
-    void add3VerticesAndImplicitEdge(){
+    void add3VerticesAndImplicitEdge() {
         stringSynonymGenerator.addSynonym("Mittelwert");
         stringSynonymGenerator.addSynonym("AVG");
         stringSynonymGenerator.addSynonym("Average");
@@ -66,63 +58,13 @@ class SynonymGeneratorTest {
         Assertions.assertEquals(3, stringSynonymGenerator.synonymsGraph.edgeSet().size());
     }
 
-    @Test
-    void getSettings(){
-        stringSynonymGenerator.addSynonym("Mittelwert");
-        stringSynonymGenerator.addSynonym("AVG");
-        stringSynonymGenerator.addSynonym("Average");
-        Set<String> stringSet = new HashSet<>(List.of("Mittelwert", "AVG", "Average"));
-        Assertions.assertEquals(stringSet, stringSynonymGenerator.getSettings());
+    @BeforeEach
+    void beforeEach() {
+        stringSynonymGenerator = new StringSynonymGenerator(PropertyOption.DEFAULT);
     }
 
     @Test
-    void removeVertex(){
-        stringSynonymGenerator.addSynonym("Mittelwert");
-        stringSynonymGenerator.addSynonym("AVG");
-        stringSynonymGenerator.addSynonym("Average");
-        stringSynonymGenerator.removeSynonym("AVG");
-        Assertions.assertEquals(2, stringSynonymGenerator.synonymsGraph.vertexSet().size());
-        Assertions.assertEquals(1, stringSynonymGenerator.synonymsGraph.edgeSet().size());
-    }
-
-    @Test
-    void searchSynonymToStringDefaultImplementation(){
-        Assertions.assertEquals("Mittelwert", stringSynonymGenerator.searchSynonymToString("Mittelwert"));
-    }
-
-    @Test
-    void regExCreationWithoutPreSuffix(){
-        stringSynonymGenerator.addSynonym("Mittelwert");
-        stringSynonymGenerator.addSynonym("AVG");
-        stringSynonymGenerator.addSynonym("Average");
-        Assertions.assertEquals("(?:Mittelwert|Average|AVG)", stringSynonymGenerator.generateRegExFor("Mittelwert"));
-    }
-
-    @Test
-    void regExCreationWithPreSuffix(){
-        stringSynonymGenerator.addSynonym("Mittelwert");
-        stringSynonymGenerator.addSynonym("AVG");
-        stringSynonymGenerator.addSynonym("Average");
-        stringSynonymGenerator.setPrefix("%");
-        stringSynonymGenerator.setSuffix("#");
-        Assertions.assertEquals("(?:%Mittelwert#|%Average#|%AVG#)", stringSynonymGenerator.generateRegExFor("Mittelwert"));
-    }
-
-    @Test
-    void regExCreationNonCapturing(){
-        stringSynonymGenerator.addSynonym("A");
-        Assertions.assertEquals("(?:A)", stringSynonymGenerator.generateRegExFor("A"));
-    }
-
-    @Test
-    void regExCreationCapturing(){
-        stringSynonymGenerator.addSynonym("A");
-        stringSynonymGenerator.setCapturingGroup(true);
-        Assertions.assertEquals("(A)", stringSynonymGenerator.generateRegExFor("A"));
-    }
-
-    @Test
-    void equalsOverride(){
+    void equalsOverride() {
         StringSynonymGenerator stringSynonymGenerator1 = getFullDefaultStringSynonymGenerator();
 
         StringSynonymGenerator stringSynonymGenerator2 = getFullDefaultStringSynonymGenerator();
@@ -143,12 +85,33 @@ class SynonymGeneratorTest {
         Assertions.assertNotEquals(stringSynonymGenerator1.hashCode(), stringSynonymGenerator2.hashCode());
     }
 
+    private StringSynonymGenerator getFullDefaultStringSynonymGenerator() {
+        StringSynonymGenerator _stringSynonymGenerator = new StringSynonymGenerator(PropertyOption.DEFAULT);
+        _stringSynonymGenerator.addSynonym("Mittelwert");
+        _stringSynonymGenerator.addSynonym("AVG");
+        _stringSynonymGenerator.addSynonym("Average");
+        _stringSynonymGenerator.setPrefix("%");
+        _stringSynonymGenerator.setSuffix("#");
+
+        return _stringSynonymGenerator;
+    }
+
     @Test
-    void hashCodeOverride(){
+    void getSettings() {
+        stringSynonymGenerator.addSynonym("Mittelwert");
+        stringSynonymGenerator.addSynonym("AVG");
+        stringSynonymGenerator.addSynonym("Average");
+        Set<String> stringSet = new HashSet<>(List.of("Mittelwert", "AVG", "Average"));
+        Assertions.assertEquals(stringSet, stringSynonymGenerator.getSettings());
+    }
+
+    @Test
+    void hashCodeOverride() {
         StringSynonymGenerator stringSynonymGenerator1 = getFullDefaultStringSynonymGenerator();
         StringSynonymGenerator stringSynonymGenerator2 = getFullDefaultStringSynonymGenerator();
 
-        Assertions.assertNotEquals(System.identityHashCode(stringSynonymGenerator1), System.identityHashCode(stringSynonymGenerator2));
+        Assertions.assertNotEquals(System.identityHashCode(stringSynonymGenerator1),
+                                   System.identityHashCode(stringSynonymGenerator2));
         Assertions.assertEquals(stringSynonymGenerator1.hashCode(), stringSynonymGenerator2.hashCode());
 
         stringSynonymGenerator1.removeSynonym("Mittelwert");
@@ -163,15 +126,51 @@ class SynonymGeneratorTest {
         Assertions.assertNotEquals(stringSynonymGenerator1.hashCode(), stringSynonymGenerator2.hashCode());
     }
 
-    private StringSynonymGenerator getFullDefaultStringSynonymGenerator(){
-        StringSynonymGenerator _stringSynonymGenerator = new StringSynonymGenerator(PropertyOption.DEFAULT);
-        _stringSynonymGenerator.addSynonym("Mittelwert");
-        _stringSynonymGenerator.addSynonym("AVG");
-        _stringSynonymGenerator.addSynonym("Average");
-        _stringSynonymGenerator.setPrefix("%");
-        _stringSynonymGenerator.setSuffix("#");
+    @Test
+    void regExCreationCapturing() {
+        stringSynonymGenerator.addSynonym("A");
+        stringSynonymGenerator.setCapturingGroup(true);
+        Assertions.assertEquals("(A)", stringSynonymGenerator.generateRegExFor("A"));
+    }
 
-        return _stringSynonymGenerator;
+    @Test
+    void regExCreationNonCapturing() {
+        stringSynonymGenerator.addSynonym("A");
+        Assertions.assertEquals("(?:A)", stringSynonymGenerator.generateRegExFor("A"));
+    }
+
+    @Test
+    void regExCreationWithPreSuffix() {
+        stringSynonymGenerator.addSynonym("Mittelwert");
+        stringSynonymGenerator.addSynonym("AVG");
+        stringSynonymGenerator.addSynonym("Average");
+        stringSynonymGenerator.setPrefix("%");
+        stringSynonymGenerator.setSuffix("#");
+        Assertions.assertEquals("(?:%Mittelwert#|%Average#|%AVG#)",
+                                stringSynonymGenerator.generateRegExFor("Mittelwert"));
+    }
+
+    @Test
+    void regExCreationWithoutPreSuffix() {
+        stringSynonymGenerator.addSynonym("Mittelwert");
+        stringSynonymGenerator.addSynonym("AVG");
+        stringSynonymGenerator.addSynonym("Average");
+        Assertions.assertEquals("(?:Mittelwert|Average|AVG)", stringSynonymGenerator.generateRegExFor("Mittelwert"));
+    }
+
+    @Test
+    void removeVertex() {
+        stringSynonymGenerator.addSynonym("Mittelwert");
+        stringSynonymGenerator.addSynonym("AVG");
+        stringSynonymGenerator.addSynonym("Average");
+        stringSynonymGenerator.removeSynonym("AVG");
+        Assertions.assertEquals(2, stringSynonymGenerator.synonymsGraph.vertexSet().size());
+        Assertions.assertEquals(1, stringSynonymGenerator.synonymsGraph.edgeSet().size());
+    }
+
+    @Test
+    void searchSynonymToStringDefaultImplementation() {
+        Assertions.assertEquals("Mittelwert", stringSynonymGenerator.searchSynonymToString("Mittelwert"));
     }
 
 


### PR DESCRIPTION
single-responsibility principle is satisfied now for building property maps
- no logic for building in the manager anymore
- therefore also no doubled tests for building in the manager tests anymore
- in sum lesser lines of code excluding all additions not directly related (e.g. new Tests that weren't covered before)
Further information about the adjustments in the commit descriptions.